### PR TITLE
Added pagination for new sales page

### DIFF
--- a/code/src/containers/products-container/ProductsContainer.scss
+++ b/code/src/containers/products-container/ProductsContainer.scss
@@ -5,24 +5,17 @@
   justify-content: space-between;
   gap: spacing(6);
 
-  @include breakpoint("xs") {
-    grid-template-columns: repeat(1, 1fr);
-  }
-
-  @include breakpoint("sm") {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  @include breakpoint("md") {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  @include breakpoint("lg") {
-    grid-template-columns: repeat(4, 1fr);
-  }
-
-  @include breakpoint("xl") {
-    grid-template-columns: repeat(5, 1fr);
+  // To generate classes that restrict number of columns
+  @for $i from 1 through 5 {
+    &__#{$i}-cols {
+      @for $j from 1 through length($breakpointsArray) {
+        @if $j <= $i {
+          @include breakpoint(nth($breakpointsArray, $j)) {
+            grid-template-columns: repeat($j, 1fr);
+          }
+        }
+      }
+    }
   }
 
   &_error {

--- a/code/src/containers/products-container/ProductsContainer.test.tsx
+++ b/code/src/containers/products-container/ProductsContainer.test.tsx
@@ -88,7 +88,7 @@ describe("Test ProductsContainer", () => {
     const { container } = renderProductsContainer({ className: "products" });
 
     const gridContainer = container.getElementsByClassName("products")[0];
-    
+
     expect(gridContainer).toBeInTheDocument();
   });
 
@@ -106,5 +106,13 @@ describe("Test ProductsContainer", () => {
     const errorElement = screen.getByText("error");
 
     expect(errorElement).toBeInTheDocument();
+  });
+
+  test("Should render different amount of columns based on passed maxColumns", () => {
+    renderProductsContainer({ maxColumns: 4 });
+
+    const gridElement = screen.getByTestId("products-container");
+
+    expect(gridElement).toHaveClass("products-container__4-cols");
   });
 });

--- a/code/src/containers/products-container/ProductsContainer.tsx
+++ b/code/src/containers/products-container/ProductsContainer.tsx
@@ -19,6 +19,7 @@ const ProductsContainer = ({
   isLoading = false,
   isError = false,
   loadingItemsCount = 5,
+  maxColumns = 5,
   errorMessage = "errors.somethingWentWrong"
 }: ProductsContainerProps) => {
   const { isLoading: isCartLoading } = useGetCart();
@@ -46,12 +47,17 @@ const ProductsContainer = ({
   const skeletonCards = repeatComponent(<ProductSkeleton />, loadingItemsCount);
 
   const isLoadingInProgress = isLoading || isAuthLoading || isCartLoading;
-  
+
   const gridItems = isLoadingInProgress ? skeletonCards : productCards;
 
   return (
     <AppBox
-      className={cn("products-container", className)}
+      className={cn(
+        "products-container",
+        `products-container__${maxColumns}-cols`,
+        className
+      )}
+      data-testid="products-container"
       data-cy="products-container"
     >
       {gridItems}

--- a/code/src/containers/products-container/ProductsContainer.types.ts
+++ b/code/src/containers/products-container/ProductsContainer.types.ts
@@ -7,6 +7,7 @@ export type ProductsContainerProps = {
   className?: string;
   isError?: boolean;
   errorMessage?: string;
+  maxColumns?: number;
 };
 
 export type HandleCartIconClickParam = Product & { isInCart: boolean };

--- a/code/src/hooks/use-products-page-size/useProductsPageSize.test.ts
+++ b/code/src/hooks/use-products-page-size/useProductsPageSize.test.ts
@@ -1,0 +1,22 @@
+import { renderHook } from "@testing-library/react";
+
+import { BREAKPOINTS } from "@/constants/breakpoints";
+import useProductsPageSize from "@/hooks/use-products-page-size/useProductsPageSize";
+
+Object.defineProperty(window, "innerWidth", {
+  writable: true,
+  configurable: true,
+  value: BREAKPOINTS.xl
+});
+
+describe("Test useProductsPageSize hook", () => {
+  test("Should return 4 for sales page", () => {
+    const { result } = renderHook(() => useProductsPageSize("sales"));
+    expect(result.current).toBe(4);
+  });
+
+  test("Should return 10 for other pages", () => {
+    const { result } = renderHook(() => useProductsPageSize());
+    expect(result.current).toBe(10);
+  });
+});

--- a/code/src/hooks/use-products-page-size/useProductsPageSize.ts
+++ b/code/src/hooks/use-products-page-size/useProductsPageSize.ts
@@ -1,0 +1,14 @@
+import useScreenSize from "@/utils/check-screen-size/useScreenSize";
+import setProductsPerPageSize from "@/utils/set-product-size/setProductsPerPageSize";
+
+const useProductsPageSize = (category?: string | null) => {
+  const screenSize = useScreenSize();
+
+  if (category === "sales") return 4;
+
+  const size = setProductsPerPageSize(screenSize.width);
+
+  return size;
+};
+
+export default useProductsPageSize;

--- a/code/src/pages/products/ProductsPage.test.tsx
+++ b/code/src/pages/products/ProductsPage.test.tsx
@@ -23,8 +23,13 @@ const mockData = { content: mockProducts, totalPages: 2, totalElements: 8 };
 
 jest.mock("@/containers/products-container/ProductsContainer", () => ({
   __esModule: true,
-  default: ({ isLoading, isError, products }: ProductsContainerProps) => (
-    <div data-testid="products-container">
+  default: ({
+    isLoading,
+    isError,
+    products,
+    maxColumns
+  }: ProductsContainerProps) => (
+    <div data-testid="products-container" data-size={maxColumns}>
       {isLoading && <div>Loading...</div>}
       {isError && <div>Error!</div>}
       {products.length > 0 &&
@@ -186,5 +191,15 @@ describe("ProductsPage", () => {
 
     expect(productsCount).toBeInTheDocument();
     expect(linksElemnts.length).toBe(0);
+  });
+
+  test("Should display only four items for sales category", () => {
+    renderAndMock({
+      entries: "/products?category=sales"
+    });
+
+    const containerElement = screen.getByTestId("products-container");
+
+    expect(containerElement).toHaveAttribute("data-size", "4");
   });
 });

--- a/code/src/pages/products/ProductsPage.tsx
+++ b/code/src/pages/products/ProductsPage.tsx
@@ -12,10 +12,10 @@ import AppTypography from "@/components/app-typography/AppTypography";
 
 import { useLocaleContext } from "@/context/i18n/I18nProvider";
 import usePagination from "@/hooks/use-pagination/usePagination";
+import usePageSize from "@/hooks/use-products-page-size/useProductsPageSize";
 import { sortOptions } from "@/pages/products/ProductsPage.constants";
 import { useGetUserProductsQuery } from "@/store/api/productsApi";
-import useScreenSize from "@/utils/check-screen-size/useScreenSize";
-import setProductsPerPageSize from "@/utils/set-product-size/setProductsPerPageSize";
+import cn from "@/utils/cn/cn";
 
 import "@/pages/products/ProductsPage.scss";
 
@@ -28,9 +28,7 @@ const ProductsPage = () => {
 
   const categoryType = searchParams.get("category");
 
-  const screenSize = useScreenSize();
-
-  const size = setProductsPerPageSize(screenSize.width);
+  const size = usePageSize(categoryType);
 
   const {
     data: productsResponse,
@@ -81,6 +79,8 @@ const ProductsPage = () => {
     }
   }, [pagesCount, page, searchParams, setSearchParams]);
 
+  const maxColumns = categoryType === "sales" ? 4 : 5;
+
   return (
     <PageWrapper>
       <AppBox className="spa-products-page" data-cy="products-page">
@@ -107,11 +107,12 @@ const ProductsPage = () => {
           />
         </AppBox>
         <ProductsContainer
-          className="spa-products-page__grid"
+          className={cn("spa-products-page__grid")}
           products={productsList ?? []}
           loadingItemsCount={10}
           isLoading={isLoading}
           isError={isError}
+          maxColumns={maxColumns}
         />
         <PaginationBlock
           page={page}

--- a/code/src/styles/foundation/_variables.scss
+++ b/code/src/styles/foundation/_variables.scss
@@ -104,6 +104,8 @@ $breakpoints: (
   xl: $screen-xl
 );
 
+$breakpointsArray: ("xs", "sm", "md", "lg", "xl");
+
 /*=====  End of BREAKPOINTS  ======*/
 
 /*=============================================


### PR DESCRIPTION
Previously, the Products page displayed a maximum of 5 columns, with the total number of items per page depending on screen width.

Since the Products page is also used for sales, I updated it to display exactly 4 items per page, regardless of screen width. This involved:

- Modifying the SCSS to create a grid layout for 4 items.
- Adjusting the logic for calculating size (products per page) so that when on the Sales page, the request always fetches 4 items per page.
- Added and edited tests.