### PR TITLE
[GS2-36] Added displaying of sale on products of cart drawer

### DIFF
--- a/code/src/containers/cart-drawer/cart-drawer-item/CartDrawerItem.scss
+++ b/code/src/containers/cart-drawer/cart-drawer-item/CartDrawerItem.scss
@@ -7,6 +7,12 @@
   border-bottom: 1px solid var(--spa-light-border-color, $light);
   position: relative;
 
+  &__discount-badge {
+    position: absolute;
+    left: 50px;
+    top: 20px;
+  }
+
   &__img {
     @include box(85px);
     object-fit: cover;
@@ -26,8 +32,24 @@
     overflow: hidden;
   }
 
+  &__price-container {
+    display: flex;
+    gap: spacing(4);
+    align-items: center;
+  }
+
   &__price {
     font-size: var(--cart-item-price-size, $fs-sm);
+
+    &-old {
+      text-decoration: line-through;
+      color: gray;
+    }
+  }
+
+  &__price-discounted {
+    font-size: var(--cart-item-price-size, $fs-sm);
+    color: red;
   }
 
   &__remove-button {

--- a/code/src/containers/cart-drawer/cart-drawer-item/CartDrawerItem.test.tsx
+++ b/code/src/containers/cart-drawer/cart-drawer-item/CartDrawerItem.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import CartDrawerItem from "@/containers/cart-drawer/cart-drawer-item/CartDrawerItem";
 
+import { CartItem } from "@/types/cart.types";
+
 const mockCartItem = {
   productId: "2",
   name: "Product 2",
@@ -9,6 +11,17 @@ const mockCartItem = {
   quantity: 1,
   image: "some image",
   calculatedPrice: 20
+};
+
+const mockCartItemWithDiscount: CartItem = {
+  productId: "2",
+  name: "Product 2",
+  productPrice: 90,
+  quantity: 1,
+  image: "some image",
+  calculatedPrice: 90,
+  discount: 10,
+  priceWithDiscount: 100
 };
 
 describe("Test CartDrawerItem", () => {
@@ -32,5 +45,27 @@ describe("Test CartDrawerItem", () => {
     fireEvent.click(removeButton);
 
     expect(onRemove).toHaveBeenCalledWith(mockCartItem);
+  });
+
+  test("Should render badge and discounted price if product is on sail", () => {
+    render(
+      <CartDrawerItem {...mockCartItemWithDiscount} onRemove={() => {}} />
+    );
+
+    const discountBadge = screen.getByTestId("cart-item-discount-badge");
+    const discountedPrice = screen.getByTestId("cart-item-discounted-price");
+
+    expect(discountBadge).toBeInTheDocument();
+    expect(discountedPrice).toBeInTheDocument();
+  });
+
+  test("Should not render badge and discounted price if product is not on sail", () => {
+    render(<CartDrawerItem {...mockCartItem} onRemove={() => {}} />);
+
+    const discountBadge = screen.queryByTestId("cart-item-discount-badge");
+    const discountedPrice = screen.queryByTestId("cart-item-discounted-price");
+
+    expect(discountBadge).not.toBeInTheDocument();
+    expect(discountedPrice).not.toBeInTheDocument();
   });
 });

--- a/code/src/containers/cart-drawer/cart-drawer-item/CartDrawerItem.tsx
+++ b/code/src/containers/cart-drawer/cart-drawer-item/CartDrawerItem.tsx
@@ -1,10 +1,13 @@
 import CloseIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box";
 
+import AppBadge from "@/components/app-badge/AppBadge";
 import AppBox from "@/components/app-box/AppBox";
 import AppIconButton from "@/components/app-icon-button/AppIconButton";
 import AppTypography from "@/components/app-typography/AppTypography";
 
 import { CartDrawerItemProps } from "@/types/cart.types";
+import cn from "@/utils/cn/cn";
 import formatPrice from "@/utils/format-price/formatPrice";
 
 import "@/containers/cart-drawer/cart-drawer-item/CartDrawerItem.scss";
@@ -14,8 +17,23 @@ const CartDrawerItem = ({ onRemove, ...props }: CartDrawerItemProps) => {
     onRemove(props);
   };
 
+  const hasDiscount = !!props.priceWithDiscount;
+
   return (
     <AppBox className="cart-item">
+      {hasDiscount && (
+        <AppBadge
+          className="cart-item__discount-badge"
+          data-testid="cart-item-discount-badge"
+          badgeContent={
+            <AppTypography variant="caption-small">
+              {`-${props.discount}%`}
+            </AppTypography>
+          }
+          variant="danger"
+          size="small"
+        />
+      )}
       <AppBox
         component="img"
         alt={props.name}
@@ -24,9 +42,26 @@ const CartDrawerItem = ({ onRemove, ...props }: CartDrawerItemProps) => {
       />
       <AppBox className="cart-item__content">
         <AppTypography className="cart-item__title">{props.name}</AppTypography>
-        <AppTypography className="cart-item__price" variant="concept">
-          {formatPrice(props.calculatedPrice)}
-        </AppTypography>
+        <Box className="cart-item__price-container">
+          <AppTypography
+            className={cn(
+              "cart-item__price",
+              hasDiscount && "cart-item__price-old"
+            )}
+            variant={hasDiscount ? "body" : "concept"}
+          >
+            {formatPrice(props.calculatedPrice)}
+          </AppTypography>
+          {hasDiscount && (
+            <AppTypography
+              className="cart-item__price-discounted"
+              variant="concept"
+              data-testid="cart-item-discounted-price"
+            >
+              {formatPrice(props.priceWithDiscount!)}
+            </AppTypography>
+          )}
+        </Box>
       </AppBox>
       <AppIconButton
         color="default"

--- a/code/src/hooks/use-add-to-cart-or-open-drawer/useAddToCartOrOpenDrawer.tsx
+++ b/code/src/hooks/use-add-to-cart-or-open-drawer/useAddToCartOrOpenDrawer.tsx
@@ -39,7 +39,9 @@ const useAddToCartOrOpenDrawer = <T extends MinimalRequiredProduct>(
       image: product.image,
       productPrice: product.price,
       quantity: 1,
-      calculatedPrice: product.price
+      calculatedPrice: product.price,
+      discount: product.discount,
+      priceWithDiscount: product.priceWithDiscount
     });
   };
 

--- a/code/src/store/slices/localCart.ts
+++ b/code/src/store/slices/localCart.ts
@@ -49,14 +49,20 @@ const localCartSlice = createSlice({
   name: sliceNames.localCart,
   reducers: {
     addToLocalCart: (state, action: PayloadAction<CartItem>) => {
-      state.totalPrice += action.payload.calculatedPrice;
+      const actualPrice =
+        action.payload.priceWithDiscount || action.payload.calculatedPrice;
+
+      state.totalPrice += actualPrice;
       state.items = [...state.items, action.payload];
     },
     removeFromLocalCart: (state, action: PayloadAction<CartItem>) => {
+      const actualPrice =
+        action.payload.priceWithDiscount || action.payload.calculatedPrice;
+
       state.items = state.items.filter(
         (item) => item.productId !== action.payload.productId
       );
-      state.totalPrice -= action.payload.calculatedPrice;
+      state.totalPrice -= actualPrice;
     },
     clearLocalCart: () => initialCart
   },

--- a/code/src/types/cart.types.ts
+++ b/code/src/types/cart.types.ts
@@ -28,6 +28,8 @@ export type CartItem = {
   productPrice: number;
   quantity: number;
   calculatedPrice: number;
+  discount?: number;
+  priceWithDiscount?: number;
 };
 
 export type CartType = {

--- a/code/src/types/product.types.ts
+++ b/code/src/types/product.types.ts
@@ -12,6 +12,8 @@ export type Product = {
   tags: string[];
   image: string;
   price: number;
+  discount?: number;
+  priceWithDiscount?: number;
 };
 
 export type ManagerProductStatus = "VISIBLE" | "HIDDEN";

--- a/mock-backend/src/data/mokedData.js
+++ b/mock-backend/src/data/mokedData.js
@@ -8,7 +8,9 @@ const products = [
     tags: ["category:mobile"],
     image:
       "https://j65jb0fdkxuua0go.public.blob.vercel-storage.com/phone_2-tTDYhyoyqsEkwPzySFdXflYCe7TkUb.jpg",
-    price: 500,
+    price: 1000,
+    discount: 50,
+    priceWithDiscount: 500,
   },
   {
     id: "124",
@@ -42,6 +44,8 @@ const products = [
     image:
       "https://j65jb0fdkxuua0go.public.blob.vercel-storage.com/tablet_2-ayF4QQ9ilJtRKlpBLCvwlJkBYddhPO.png",
     price: 999,
+    discount: 40,
+    priceWithDiscount: 500,
   },
   {
     id: "127",
@@ -53,6 +57,8 @@ const products = [
     image:
       "https://j65jb0fdkxuua0go.public.blob.vercel-storage.com/computer_1-J0a7bI2jB5NozuSaXnzyMtxHyijWoD.jpg",
     price: 1999,
+    discount: 40,
+    priceWithDiscount: 500,
   },
   {
     id: "128",


### PR DESCRIPTION
- Added displaying of sale inside of cart drawer. There is a badge, original price and price with discount. Total is counted including discount.
- Added unit tests

The first item is on sale. The second is not on sail.
![image](https://github.com/user-attachments/assets/069f5b84-d5a7-45ad-a2dc-08c8c5873ba8)
