### PR TITLE
[GS3-42] Implement customer account title desc component

### DIFF
--- a/code/src/components/account-page/AccountTitle.module.scss
+++ b/code/src/components/account-page/AccountTitle.module.scss
@@ -1,0 +1,21 @@
+@import "@design-system";
+
+.accountTitle {
+  margin-bottom: 0.75rem;
+
+  &__title {
+    font-size: 1.75rem;
+    font-weight: map-get($fw, extra-bold);
+    font-family: $inter;
+    margin: 0;
+    color: $black;
+  }
+
+  &__description {
+    font-size: map-get($fs, base);
+    font-weight: map-get($fw, regular);
+    font-family: $inter;
+    color: $gray-light;
+    margin: 0.25rem 0 0;
+  }
+}

--- a/code/src/components/account-page/AccountTitle.test.tsx
+++ b/code/src/components/account-page/AccountTitle.test.tsx
@@ -15,7 +15,7 @@ describe("AccountTitle", () => {
     expect(screen.getByText("Manage your account")).toBeInTheDocument();
   });
 
-  it("should not render description when not provided", () => {
+  it("should render title and not render description when not provided", () => {
     render(<AccountTitle title="Customer Account" />);
 
     expect(screen.getByText("Customer Account")).toBeInTheDocument();

--- a/code/src/components/account-page/AccountTitle.test.tsx
+++ b/code/src/components/account-page/AccountTitle.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+
+import AccountTitle from "./AccountTitle";
+
+describe("AccountTitle", () => {
+  it("should render title", () => {
+    render(<AccountTitle title="Customer Account" />);
+    expect(screen.getByText("Customer Account")).toBeInTheDocument();
+  });
+
+  it("should render description when provided", () => {
+    render(
+      <AccountTitle
+        title="Customer Account"
+        description="Manage your account"
+      />
+    );
+    expect(screen.getByText("Manage your account")).toBeInTheDocument();
+  });
+
+  it("should not render description when not provided", () => {
+    render(<AccountTitle title="Customer Account" />);
+    const description = screen.queryByText("Manage your account");
+    expect(description).not.toBeInTheDocument();
+  });
+});

--- a/code/src/components/account-page/AccountTitle.test.tsx
+++ b/code/src/components/account-page/AccountTitle.test.tsx
@@ -3,24 +3,22 @@ import { render, screen } from "@testing-library/react";
 import AccountTitle from "./AccountTitle";
 
 describe("AccountTitle", () => {
-  it("should render title", () => {
-    render(<AccountTitle title="Customer Account" />);
-    expect(screen.getByText("Customer Account")).toBeInTheDocument();
-  });
-
-  it("should render description when provided", () => {
+  it("should render title and optional description when provided", () => {
     render(
       <AccountTitle
         title="Customer Account"
         description="Manage your account"
       />
     );
+
+    expect(screen.getByText("Customer Account")).toBeInTheDocument();
     expect(screen.getByText("Manage your account")).toBeInTheDocument();
   });
 
   it("should not render description when not provided", () => {
     render(<AccountTitle title="Customer Account" />);
-    const description = screen.queryByText("Manage your account");
-    expect(description).not.toBeInTheDocument();
+
+    expect(screen.getByText("Customer Account")).toBeInTheDocument();
+    expect(screen.queryByText("Manage your account")).not.toBeInTheDocument();
   });
 });

--- a/code/src/components/account-page/AccountTitle.tsx
+++ b/code/src/components/account-page/AccountTitle.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import * as styles from "./AccountTitle.module.scss";
+
+interface AccountTitleProps {
+  title: string;
+  description?: string;
+}
+
+const AccountTitle: React.FC<AccountTitleProps> = ({ title, description }) => {
+  return (
+    <div className={styles.accountTitle}>
+      <h1 className={styles.accountTitle__title}>{title}</h1>
+      {description && (
+        <p className={styles.accountTitle__description}>{description}</p>
+      )}
+    </div>
+  );
+};
+
+export default AccountTitle;

--- a/code/src/components/account-page/AccountTitle.tsx
+++ b/code/src/components/account-page/AccountTitle.tsx
@@ -2,6 +2,9 @@ import React from "react";
 
 import * as styles from "./AccountTitle.module.scss";
 
+import AppBox from "../app-box/AppBox";
+import AppTypography from "../app-typography/AppTypography";
+
 type AccountTitleProps = {
   title: string;
   description?: string;
@@ -9,12 +12,20 @@ type AccountTitleProps = {
 
 const AccountTitle: React.FC<AccountTitleProps> = ({ title, description }) => {
   return (
-    <div className={styles.accountTitle}>
-      <h1 className={styles.accountTitle__title}>{title}</h1>
+    <AppBox className={styles.accountTitle}>
+      <AppTypography variant="h1" className={styles.accountTitle__title}>
+        {title}
+      </AppTypography>
+
       {description && (
-        <p className={styles.accountTitle__description}>{description}</p>
+        <AppTypography
+          variant="body"
+          className={styles.accountTitle__description}
+        >
+          {description}
+        </AppTypography>
       )}
-    </div>
+    </AppBox>
   );
 };
 

--- a/code/src/components/account-page/AccountTitle.tsx
+++ b/code/src/components/account-page/AccountTitle.tsx
@@ -2,10 +2,10 @@ import React from "react";
 
 import * as styles from "./AccountTitle.module.scss";
 
-interface AccountTitleProps {
+type AccountTitleProps = {
   title: string;
   description?: string;
-}
+};
 
 const AccountTitle: React.FC<AccountTitleProps> = ({ title, description }) => {
   return (

--- a/code/src/scss.d.ts
+++ b/code/src/scss.d.ts
@@ -1,0 +1,4 @@
+declare module "*.module.scss" {
+  const classes: { [key: string]: string };
+  export = classes;
+}


### PR DESCRIPTION
## Description:

* Reusable UI block for displaying a section title with an optional description
* Styled using SCSS modules with BEM naming convention
* Props: `title` (required), `description` (optional)
* Includes unit tests for:

  * Rendering the title
  * Rendering the optional description
  * Not rendering the description when not provided
* Ensures consistent layout and typography across account-related pages

![image](https://github.com/user-attachments/assets/3f27516f-4ff1-4bcf-a215-996380133168)
![image](https://github.com/user-attachments/assets/aa2e7f0b-bc87-4f61-a019-7d89ec51b656)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new AccountTitle component that displays a title and an optional description on the account page.
* **Style**
  * Added new styles for the AccountTitle component to improve visual presentation.
* **Tests**
  * Added tests to ensure the AccountTitle component displays the title and description correctly.
* **Chores**
  * Enhanced TypeScript support for SCSS modules to improve type-checking and development experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->