### PR TITLE
[GS3-34] Display account icon in header for authenticated users

### DIFF
--- a/code/src/components/app-menu/AppMenu.test.tsx
+++ b/code/src/components/app-menu/AppMenu.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+
+import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
+import userEvent from "@testing-library/user-event";
+
+
+import AppMenu from "@/components/app-menu/AppMenu";
+import { MenuItem } from "@/components/app-menu/AppMenu.types";
+
+jest.mock("@/components/app-menu-item/AppMenuItem", () => (props: any) => (
+  <div onClick={props.onClick}>{props.children}</div>
+));
+
+const mockedOnClick = jest.fn();
+const mockedOnClose = jest.fn();
+const mockMenuItems: MenuItem[] = [
+  {
+    id: 1,
+    name: "myProfile",
+    icon: AccountCircleRoundedIcon,
+    onClick: mockedOnClick
+  }
+];
+
+describe("AppMenu", () => {
+  beforeEach(() => {
+    render(
+      <AppMenu
+        anchorEl={document.createElement("div")}
+        open={true}
+        onClose={mockedOnClose}
+        items={mockMenuItems}
+      />
+    );
+  });
+
+  it("should render without crashing", () => {
+    const menu = screen.getByText("myProfile");
+    expect(menu).toBeInTheDocument();
+  });
+
+  it("should call onClick and onClose handlers", async () => {
+    const menu = screen.getByText("myProfile");
+
+    await userEvent.click(menu);
+    expect(mockedOnClick).toHaveBeenCalled();
+    expect(mockedOnClose).toHaveBeenCalled();
+  });
+});

--- a/code/src/components/app-menu/AppMenu.test.tsx
+++ b/code/src/components/app-menu/AppMenu.test.tsx
@@ -3,13 +3,17 @@ import { render, screen } from "@testing-library/react";
 import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
 import userEvent from "@testing-library/user-event";
 
-
+import { AppMenuItemProps } from "@/components/app-menu-item/AppMenuItem.types";
 import AppMenu from "@/components/app-menu/AppMenu";
 import { MenuItem } from "@/components/app-menu/AppMenu.types";
 
-jest.mock("@/components/app-menu-item/AppMenuItem", () => (props: any) => (
-  <div onClick={props.onClick}>{props.children}</div>
-));
+jest.mock("@/components/app-menu-item/AppMenuItem", () => {
+  const MockAppMenuItem = (props: AppMenuItemProps) => (
+    <li onClick={props.onClick}>{props.children}</li>
+  );
+  MockAppMenuItem.displaName = "MockAppMenuItem";
+  return MockAppMenuItem;
+});
 
 const mockedOnClick = jest.fn();
 const mockedOnClose = jest.fn();

--- a/code/src/components/app-menu/AppMenu.test.tsx
+++ b/code/src/components/app-menu/AppMenu.test.tsx
@@ -11,7 +11,7 @@ jest.mock("@/components/app-menu-item/AppMenuItem", () => {
   const MockAppMenuItem = (props: AppMenuItemProps) => (
     <li onClick={props.onClick}>{props.children}</li>
   );
-  MockAppMenuItem.displaName = "MockAppMenuItem";
+  MockAppMenuItem.displayName = "MockAppMenuItem";
   return MockAppMenuItem;
 });
 

--- a/code/src/components/app-menu/AppMenu.test.tsx
+++ b/code/src/components/app-menu/AppMenu.test.tsx
@@ -27,7 +27,7 @@ const mockMenuItems: MenuItem[] = [
 ];
 
 describe("AppMenu", () => {
-  beforeEach(() => {
+  it("should render without crashing", () => {
     render(
       <AppMenu
         anchorEl={document.createElement("div")}
@@ -36,18 +36,38 @@ describe("AppMenu", () => {
         items={mockMenuItems}
       />
     );
-  });
-
-  it("should render without crashing", () => {
     const menu = screen.getByText("myProfile");
     expect(menu).toBeInTheDocument();
   });
 
   it("should call onClick and onClose handlers", async () => {
+    render(
+      <AppMenu
+        anchorEl={document.createElement("div")}
+        open={true}
+        onClose={mockedOnClose}
+        items={mockMenuItems}
+      />
+    );
     const menu = screen.getByText("myProfile");
 
     await userEvent.click(menu);
     expect(mockedOnClick).toHaveBeenCalled();
     expect(mockedOnClose).toHaveBeenCalled();
+  });
+
+  it('should show "No available options" when no items', () => {
+    render(
+      <AppMenu
+        anchorEl={document.createElement("div")}
+        open={true}
+        onClose={mockedOnClose}
+        items={[]}
+      />
+    );
+
+    const defaultResponse = screen.getByText("appMenu.noOptions");
+
+    expect(defaultResponse).toBeInTheDocument();
   });
 });

--- a/code/src/components/app-menu/AppMenu.tsx
+++ b/code/src/components/app-menu/AppMenu.tsx
@@ -5,14 +5,9 @@ import { AppMenuProps } from "@/components/app-menu/AppMenu.types";
 import AppTypography from "@/components/app-typography/AppTypography";
 
 const AppMenu = ({ anchorEl, open, onClose, items }: AppMenuProps) => {
-  return (
-    <Menu
-      className="spa-menu"
-      anchorEl={anchorEl}
-      open={open}
-      onClose={onClose}
-    >
-      {items.map(({ id, name, icon: Icon, onClick }) => (
+  const content =
+    items.length > 0 ? (
+      items.map(({ id, name, icon: Icon, onClick }) => (
         <AppMenuItem
           key={id}
           onClick={() => {
@@ -24,7 +19,21 @@ const AppMenu = ({ anchorEl, open, onClose, items }: AppMenuProps) => {
           <Icon className="header__toolbar-icon-dropdown" fontSize="medium" />
           <AppTypography variant="subtitle2" translationKey={name} />
         </AppMenuItem>
-      ))}
+      ))
+    ) : (
+      <AppMenuItem disabled>
+        <AppTypography variant="caption" translationKey="appMenu.noOptions" />
+      </AppMenuItem>
+    );
+
+  return (
+    <Menu
+      className="spa-menu"
+      anchorEl={anchorEl}
+      open={open}
+      onClose={onClose}
+    >
+      {content}
     </Menu>
   );
 };

--- a/code/src/components/app-menu/AppMenu.tsx
+++ b/code/src/components/app-menu/AppMenu.tsx
@@ -1,0 +1,32 @@
+import Menu from "@mui/material/Menu";
+
+import AppMenuItem from "@/components/app-menu-item/AppMenuItem";
+import { AppMenuProps } from "@/components/app-menu/AppMenu.types";
+import AppTypography from "@/components/app-typography/AppTypography";
+
+const AppMenu = ({ anchorEl, open, onClose, items }: AppMenuProps) => {
+  return (
+    <Menu
+      className="spa-menu"
+      anchorEl={anchorEl}
+      open={open}
+      onClose={onClose}
+    >
+      {items.map(({ id, name, icon: Icon, onClick }) => (
+        <AppMenuItem
+          key={id}
+          onClick={() => {
+            onClick();
+            onClose();
+          }}
+          data-cy={`${name}-item`}
+        >
+          <Icon className="header__toolbar-icon-dropdown" fontSize="medium" />
+          <AppTypography variant="subtitle2" translationKey={name} />
+        </AppMenuItem>
+      ))}
+    </Menu>
+  );
+};
+
+export default AppMenu;

--- a/code/src/components/app-menu/AppMenu.types.ts
+++ b/code/src/components/app-menu/AppMenu.types.ts
@@ -1,0 +1,14 @@
+import type { SvgIconComponent } from "@mui/icons-material";
+
+export interface MenuItem {
+  id: number;
+  name: string;
+  icon: SvgIconComponent;
+  onClick: () => void;
+}
+export interface AppMenuProps {
+  anchorEl: HTMLElement | null;
+  open: boolean;
+  onClose: () => void;
+  items: MenuItem[];
+}

--- a/code/src/constants/api-tags.ts
+++ b/code/src/constants/api-tags.ts
@@ -7,7 +7,8 @@ export const rtkQueryTags = {
   BESTSELLERS: "BESTSELLERS",
   SALES: "SALES",
   ARTICLES: "ARTICLES",
-  SUGGESTED_PRODUCT: "SUGGESTED_PRODUCT"
+  SUGGESTED_PRODUCT: "SUGGESTED_PRODUCT",
+  USER_PROFILE: "USER_PROFILE",
 } as const;
 
 export const rtkQueryTagsArray = Object.values(rtkQueryTags);

--- a/code/src/constants/common-messages/en.json
+++ b/code/src/constants/common-messages/en.json
@@ -49,5 +49,6 @@
   "product.priceWithDiscount": "Price with discount",
   "product.originalPrice": "Price",
   "product.discountPercentage": "Discount percentage",
-  "loading.label": "Loading..."
+  "loading.label": "Loading...",
+  "appMenu.noOptions": "No available options"
 }

--- a/code/src/constants/common-messages/uk.json
+++ b/code/src/constants/common-messages/uk.json
@@ -49,5 +49,6 @@
   "product.priceWithDiscount": "Ціна зі знижкою",
   "product.originalPrice": "Ціна",
   "product.discountPercentage": "Розмір знижки",
-  "loading.label": "Завантаження..."
+  "loading.label": "Завантаження...",
+  "appMenu.noOptions": "Немає доступних опцій"
 }

--- a/code/src/constants/requests.ts
+++ b/code/src/constants/requests.ts
@@ -85,5 +85,8 @@ export const URLS = {
   },
   metrics: {
     getMetrics: "/v1/filter-analytics/products-on-sale/weekly"
+  },
+  userInfo: {
+    getUserInfo: "/v2/myInfo"
   }
 } as const;

--- a/code/src/constants/routes.ts
+++ b/code/src/constants/routes.ts
@@ -31,6 +31,9 @@ const routes = {
   orders: {
     path: "/orders"
   },
+  userCabinet: {
+    path: '/user-cabinet'
+  },
   dashboard: {
     path: "/dashboard",
     orders: {

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants.tsx
@@ -1,0 +1,42 @@
+import { useNavigate } from "react-router-dom";
+
+import type { SvgIconComponent } from "@mui/icons-material";
+import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
+import ListAltIcon from "@mui/icons-material/ListAlt";
+import LogoutIcon from "@mui/icons-material/Logout";
+
+import type { MenuItem } from "@/components/app-menu/AppMenu.types";
+
+import routes from "@/constants/routes";
+
+type IconName = "AccountCircleRounded" | "ListAlt" | "Logout";
+
+export const menuIcons: Record<IconName, SvgIconComponent> = {
+  AccountCircleRounded: AccountCircleRoundedIcon,
+  ListAlt: ListAltIcon,
+  Logout: LogoutIcon
+};
+
+export const getHeaderMenuList = (
+  navigate: ReturnType<typeof useNavigate>,
+  handleLogout: () => void
+): MenuItem[] => [
+  {
+    id: 1,
+    name: "header.myProfile",
+    icon: menuIcons.AccountCircleRounded,
+    onClick: () => navigate(routes.userCabinet.path)
+  },
+  {
+    id: 2,
+    name: "header.orders",
+    icon: menuIcons.ListAlt,
+    onClick: () => navigate(routes.orders.path)
+  },
+  {
+    id: 3,
+    name: "header.logout",
+    icon: menuIcons.Logout,
+    onClick: () => handleLogout()
+  }
+];

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants.tsx
@@ -1,42 +1,36 @@
-import type { useNavigate } from "react-router-dom";
-
 import type { SvgIconComponent } from "@mui/icons-material";
 import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
 import ListAltIcon from "@mui/icons-material/ListAlt";
 import LogoutIcon from "@mui/icons-material/Logout";
 
-import type { MenuItem } from "@/components/app-menu/AppMenu.types";
-
 import routes from "@/constants/routes";
 
-type IconName = "AccountCircleRounded" | "ListAlt" | "Logout";
+type MenuAction = { type: "navigate"; path: string } | { type: "logout" };
 
-export const menuIcons: Record<IconName, SvgIconComponent> = {
-  AccountCircleRounded: AccountCircleRoundedIcon,
-  ListAlt: ListAltIcon,
-  Logout: LogoutIcon
-};
+export interface RawMenuItem {
+  id: number;
+  name: string;
+  icon: SvgIconComponent;
+  action: MenuAction;
+}
 
-export const getHeaderMenuList = (
-  navigate: ReturnType<typeof useNavigate>,
-  handleLogout: () => void
-): MenuItem[] => [
+export const rawMenuItems: RawMenuItem[] = [
   {
     id: 1,
     name: "header.myProfile",
-    icon: menuIcons.AccountCircleRounded,
-    onClick: () => navigate(routes.userCabinet.path)
+    icon: AccountCircleRoundedIcon,
+    action: { type: "navigate", path: routes.userCabinet.path }
   },
   {
     id: 2,
     name: "header.orders",
-    icon: menuIcons.ListAlt,
-    onClick: () => navigate(routes.orders.path)
+    icon: ListAltIcon,
+    action: { type: "navigate", path: routes.orders.path }
   },
   {
     id: 3,
     name: "header.logout",
-    icon: menuIcons.Logout,
-    onClick: () => handleLogout()
+    icon: LogoutIcon,
+    action: { type: "logout" }
   }
 ];

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import type { useNavigate } from "react-router-dom";
 
 import type { SvgIconComponent } from "@mui/icons-material";
 import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
@@ -6,16 +6,14 @@ import HeaderAccountButton from "@/layouts/header/components/header-buttons/head
 
 import { AppMenuProps, MenuItem } from "@/components/app-menu/AppMenu.types";
 
+import { useGetUserInfoQuery } from "@/store/api/userProfileApi";
+import { RTKQueryMockState } from "@/types/common";
+import { UserResponse } from "@/types/user.types";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
 
-jest.mock(
-  "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants",
-  () => ({
-    getHeaderMenuList: jest.fn(() => [
-      { id: 1, name: "Profile", onClick: jest.fn() }
-    ])
-  })
-);
+jest.mock("@/store/api/userProfileApi", () => ({
+  useGetUserInfoQuery: jest.fn()
+}));
 jest.mock("@/components/app-menu/AppMenu", () => ({
   __esModule: true,
   default: ({ open, onClose, items }: AppMenuProps) =>
@@ -37,24 +35,48 @@ jest.mock("@/components/app-menu/AppMenu", () => ({
     ) : null
 }));
 
-describe("HeaderAccountButton", () => {
-  beforeEach(() => {
-    renderWithProviders(<HeaderAccountButton />);
+const defaultArgs: RTKQueryMockState<UserResponse> = {
+  data: null,
+  isError: false,
+  isLoading: false
+};
+const mockData = {
+  data: { photo: "https://example.com/photo.jpg" }
+};
+
+const mockAndRender = (args?: RTKQueryMockState<Partial<UserResponse>>) => {
+  (useGetUserInfoQuery as jest.Mock).mockReturnValue({
+    ...defaultArgs,
+    ...args
   });
 
+  renderWithProviders(<HeaderAccountButton />);
+};
+
+describe("HeaderAccountButton", () => {
   it("should render HeaderAccountButton", () => {
+    mockAndRender();
     const accountButton = screen.getByTestId("header-account-button");
     expect(accountButton).toBeInTheDocument();
   });
 
+  it("should render HeaderAccountButton with img", () => {
+    mockAndRender(mockData);
+
+    const photo = screen.getByTestId("header-account-photo");
+    expect(photo).toBeInTheDocument();
+    expect(photo).toHaveAttribute("src", mockData.data.photo);
+  });
+
   it("should open menu and close when menuItem is clicked", async () => {
+    mockAndRender();
     const accountButton = screen.getByTestId("header-account-button");
     expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
 
     await userEvent.click(accountButton);
 
     expect(screen.getByTestId("menu")).toBeInTheDocument();
-    expect(screen.getByText("Profile")).toBeInTheDocument();
+    expect(screen.getByText("header.myProfile")).toBeInTheDocument();
 
     await userEvent.click(screen.getByTestId("menu-item-0"));
 

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
@@ -4,6 +4,8 @@ import userEvent from "@testing-library/user-event";
 
 import HeaderAccountButton from "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton";
 
+import { AppMenuProps, MenuItem } from "@/components/app-menu/AppMenu.types";
+
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
 
 jest.mock(
@@ -16,10 +18,10 @@ jest.mock(
 );
 jest.mock("@/components/app-menu/AppMenu", () => ({
   __esModule: true,
-  default: ({ open, onClose, items }: any) =>
+  default: ({ open, onClose, items }: AppMenuProps) =>
     open ? (
       <div data-testid="menu">
-        {items.map((item: any, index: number) => (
+        {items.map((item: MenuItem, index: number) => (
           <div
             key={index}
             data-testid={`menu-item-${index}`}

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from "@testing-library/react";
+
+import userEvent from "@testing-library/user-event";
+
+import HeaderAccountButton from "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton";
+
+import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
+
+jest.mock(
+  "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants",
+  () => ({
+    getHeaderMenuList: jest.fn(() => [
+      { id: 1, name: "Profile", onClick: jest.fn() }
+    ])
+  })
+);
+jest.mock("@/components/app-menu/AppMenu", () => ({
+  __esModule: true,
+  default: ({ open, onClose, items }: any) =>
+    open ? (
+      <div data-testid="menu">
+        {items.map((item: any, index: number) => (
+          <div
+            key={index}
+            data-testid={`menu-item-${index}`}
+            onClick={() => {
+              item.onClick();
+              onClose();
+            }}
+          >
+            {item.name}
+          </div>
+        ))}
+      </div>
+    ) : null
+}));
+
+describe("HeaderAccountButton", () => {
+  beforeEach(() => {
+    renderWithProviders(<HeaderAccountButton />);
+  });
+
+  it("should render HeaderAccountButton", () => {
+    const accountButton = screen.getByTestId("header-account-button");
+    expect(accountButton).toBeInTheDocument();
+  });
+
+  it("should open menu and close when menuItem is clicked", async () => {
+    const accountButton = screen.getByTestId("header-account-button");
+    expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+
+    await userEvent.click(accountButton);
+
+    expect(screen.getByTestId("menu")).toBeInTheDocument();
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("menu-item-0"));
+
+    expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+  });
+});

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.tsx
@@ -3,18 +3,42 @@ import { useNavigate } from "react-router-dom";
 
 import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
 
-import { getHeaderMenuList } from "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants";
+import { getHeaderMenuList } from "@/layouts/header/utils/get-header-menu-list/getHeaderMenuList";
 
+import AppBox from "@/components/app-box/AppBox";
 import AppIconButton from "@/components/app-icon-button/AppIconButton";
 import AppMenu from "@/components/app-menu/AppMenu";
 
 import useLogout from "@/hooks/use-logout/useLogout";
+import { useGetUserInfoQuery } from "@/store/api/userProfileApi";
+
+import { rawMenuItems } from "./HeaderAccountButton.constants";
 
 const HeaderAccountButton = () => {
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleLogout = useLogout();
+  const { data } = useGetUserInfoQuery();
+
+  const profilePhoto = data?.photo;
+
+  const profileIconOrPhoto = profilePhoto ? (
+    <AppBox className="header__toolbar-profile-img-wrapper">
+      <AppBox
+        component="img"
+        src={profilePhoto}
+        alt="Profile photo"
+        className="header__toolbar-profile-img"
+        data-testid="header-account-photo"
+      />
+    </AppBox>
+  ) : (
+    <AccountCircleRoundedIcon
+      className="header__toolbar-icon"
+      fontSize="medium"
+    />
+  );
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -23,7 +47,7 @@ const HeaderAccountButton = () => {
     setAnchorEl(null);
   };
 
-  const menuList = getHeaderMenuList(navigate, handleLogout);
+  const menuList = getHeaderMenuList(rawMenuItems, navigate, handleLogout);
 
   return (
     <>
@@ -32,10 +56,7 @@ const HeaderAccountButton = () => {
         data-testid="header-account-button"
         onClick={handleClick}
       >
-        <AccountCircleRoundedIcon
-          className="header__toolbar-icon"
-          fontSize="medium"
-        />
+        {profileIconOrPhoto}
       </AppIconButton>
       <AppMenu
         anchorEl={anchorEl}

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
+
+import { getHeaderMenuList } from "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants";
+
+import AppIconButton from "@/components/app-icon-button/AppIconButton";
+import AppMenu from "@/components/app-menu/AppMenu";
+
+import useLogout from "@/hooks/use-logout/useLogout";
+
+const HeaderAccountButton = () => {
+  const navigate = useNavigate();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleLogout = useLogout();
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const menuList = getHeaderMenuList(navigate, handleLogout);
+
+  return (
+    <>
+      <AppIconButton
+        data-cy="header-account-button"
+        data-testid="header-account-button"
+        onClick={handleClick}
+      >
+        <AccountCircleRoundedIcon
+          className="header__toolbar-icon"
+          fontSize="medium"
+        />
+      </AppIconButton>
+      <AppMenu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        items={menuList}
+      />
+    </>
+  );
+};
+
+export default HeaderAccountButton;

--- a/code/src/layouts/header/components/header-toolbar/HeaderToolbar.scss
+++ b/code/src/layouts/header/components/header-toolbar/HeaderToolbar.scss
@@ -24,6 +24,10 @@
     color: var(--spa-cart-icon-color, $black);
   }
 
+  &-icon-dropdown {
+    margin-right: spacing(2);
+  }
+
   &-action {
     width: 100%;
     display: flex;

--- a/code/src/layouts/header/components/header-toolbar/HeaderToolbar.scss
+++ b/code/src/layouts/header/components/header-toolbar/HeaderToolbar.scss
@@ -28,6 +28,22 @@
     margin-right: spacing(2);
   }
 
+  &-profile-img-wrapper {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &-profile-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
   &-action {
     width: 100%;
     display: flex;

--- a/code/src/layouts/header/components/header-toolbar/header-user-toolbar/HeaderUserToolbar.test.tsx
+++ b/code/src/layouts/header/components/header-toolbar/header-user-toolbar/HeaderUserToolbar.test.tsx
@@ -10,30 +10,21 @@ jest.mock(
   })
 );
 jest.mock(
-  "@/layouts/header/components/header-buttons/header-logout-button/HeaderLogoutButton",
+  "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton",
   () => ({
     __esModule: true,
-    default: () => <div>Logout Button</div>
-  })
-);
-jest.mock(
-  "@/layouts/header/components/header-buttons/header-orders-button/HeaderOrdersButton",
-  () => ({
-    __esModule: true,
-    default: () => <div>Orders Button</div>
+    default: () => <div>Account Button</div>
   })
 );
 
 describe("Test HeaderUserToolbar", () => {
-  it("should render the cart button, orders button and logout button", () => {
+  it("should render the cart button and account button", () => {
     render(<HeaderUserToolbar />);
 
     const cartButton = screen.getByText("Cart Button");
-    const ordersButton = screen.getByText("Orders Button");
-    const logoutButton = screen.getByText("Logout Button");
+    const accountButton = screen.getByText("Account Button");
 
     expect(cartButton).toBeInTheDocument();
-    expect(logoutButton).toBeInTheDocument();
-    expect(ordersButton).toBeInTheDocument();
+    expect(accountButton).toBeInTheDocument();
   });
 });

--- a/code/src/layouts/header/components/header-toolbar/header-user-toolbar/HeaderUserToolbar.tsx
+++ b/code/src/layouts/header/components/header-toolbar/header-user-toolbar/HeaderUserToolbar.tsx
@@ -1,13 +1,11 @@
+import HeaderAccountButton from "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton";
 import HeaderCartButton from "@/layouts/header/components/header-buttons/header-cart-button/HeaderCartButton";
-import HeaderLogoutButton from "@/layouts/header/components/header-buttons/header-logout-button/HeaderLogoutButton";
-import HeaderOrdersButton from "@/layouts/header/components/header-buttons/header-orders-button/HeaderOrdersButton";
 
 const HeaderUserToolbar = () => {
   return (
     <>
-      <HeaderOrdersButton />
       <HeaderCartButton />
-      <HeaderLogoutButton />
+      <HeaderAccountButton />
     </>
   );
 };

--- a/code/src/layouts/header/messages/en.json
+++ b/code/src/layouts/header/messages/en.json
@@ -1,5 +1,8 @@
 {
   "header.searchInputPlaceholder": "Search...",
   "header.searchInputNoResults": "No results found",
-  "header.searchInputResults": "Search results:"
+  "header.searchInputResults": "Search results:",
+  "header.myProfile": "My profile",
+  "header.orders": "Orders",
+  "header.logout": "Logout"
 }

--- a/code/src/layouts/header/messages/uk.json
+++ b/code/src/layouts/header/messages/uk.json
@@ -1,5 +1,8 @@
 {
   "header.searchInputPlaceholder": "Пошук...",
   "header.searchInputNoResults": "Результатів не знайдено",
-  "header.searchInputResults": "Результати пошуку:"
+  "header.searchInputResults": "Результати пошуку:",
+  "header.myProfile": "Мій профіль",
+  "header.orders": "Замовлення",
+  "header.logout": "Вийти"
 }

--- a/code/src/layouts/header/utils/get-header-menu-list/getHeaderMenuList.test.tsx
+++ b/code/src/layouts/header/utils/get-header-menu-list/getHeaderMenuList.test.tsx
@@ -1,0 +1,77 @@
+import ListAltIcon from "@mui/icons-material/ListAlt";
+import LogoutIcon from "@mui/icons-material/Logout";
+
+import { RawMenuItem } from "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants";
+
+import { getHeaderMenuList } from "./getHeaderMenuList";
+
+const mockNavigate = jest.fn();
+const mockLogout = jest.fn();
+
+const logoutItem: RawMenuItem = {
+  id: 1,
+  name: "Logout",
+  icon: LogoutIcon,
+  action: { type: "logout" }
+};
+
+const ordersItem: RawMenuItem = {
+  id: 2,
+  name: "Orders",
+  icon: ListAltIcon,
+  action: { type: "navigate", path: "/orders" }
+};
+
+describe("getHeaderMenuList", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should map logout action to handleLogout", () => {
+    const menu = getHeaderMenuList([logoutItem], mockNavigate, mockLogout);
+
+    expect(menu).toHaveLength(1);
+    expect(menu[0].id).toBe(logoutItem.id);
+    expect(menu[0].name).toBe(logoutItem.name);
+    expect(menu[0].icon).toBe(logoutItem.icon);
+    expect(typeof menu[0].onClick).toBe("function");
+
+    menu[0].onClick();
+
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should map navigate action to navigate function", () => {
+    const menu = getHeaderMenuList([ordersItem], mockNavigate, mockLogout);
+
+    expect(menu).toHaveLength(1);
+    expect(menu[0].id).toBe(ordersItem.id);
+    expect(menu[0].name).toBe(ordersItem.name);
+    expect(menu[0].icon).toBe(ordersItem.icon);
+    expect(typeof menu[0].onClick).toBe("function");
+
+    menu[0].onClick();
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith("/orders");
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it("should map multiple items correctly", () => {
+    const menu = getHeaderMenuList(
+      [logoutItem, ordersItem],
+      mockNavigate,
+      mockLogout
+    );
+
+    expect(menu).toHaveLength(2);
+
+    menu[0].onClick();
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+
+    menu[1].onClick();
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith("/orders");
+  });
+});

--- a/code/src/layouts/header/utils/get-header-menu-list/getHeaderMenuList.tsx
+++ b/code/src/layouts/header/utils/get-header-menu-list/getHeaderMenuList.tsx
@@ -1,0 +1,18 @@
+import { RawMenuItem } from "@/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.constants";
+
+import type { MenuItem } from "@/components/app-menu/AppMenu.types";
+
+export const getHeaderMenuList = (
+  items: RawMenuItem[],
+  navigate: (path: string) => void,
+  handleLogout: () => void
+): MenuItem[] =>
+  items.map(
+    ({ id, name, icon, action }): MenuItem => ({
+      id,
+      name,
+      icon,
+      onClick:
+        action.type === "logout" ? handleLogout : () => navigate(action.path)
+    })
+  );

--- a/code/src/pages/user-account/UserCabinetPage.tsx
+++ b/code/src/pages/user-account/UserCabinetPage.tsx
@@ -1,0 +1,7 @@
+import AppTypography from "@/components/app-typography/AppTypography";
+
+const UserCabinetPage = () => {
+  return <AppTypography>UserCabinetPage</AppTypography>;
+};
+
+export default UserCabinetPage;

--- a/code/src/routes/protectedRoutes.tsx
+++ b/code/src/routes/protectedRoutes.tsx
@@ -37,6 +37,9 @@ const DashboardUpdateProductPage = lazy(
 const DashboardProductPage = lazy(
   () => import("@/pages/dashboard/dashboard-product/DashboardProductPage")
 );
+const UserCabinetPage = lazy(
+  () => import("@/pages/user-account/UserCabinetPage")
+);
 
 const protectedRoutes: RouteObject[] = [
   {
@@ -97,6 +100,15 @@ const protectedRoutes: RouteObject[] = [
       <ProtectedRoute
         element={<CartPage />}
         allowedRoles={[ROLES.ADMIN, ROLES.SHOP_MANAGER, ROLES.USER]}
+      />
+    )
+  },
+  {
+    path: routePaths.userCabinet.path,
+    element: (
+      <ProtectedRoute
+        element={<UserCabinetPage />}
+        allowedRoles={[ROLES.USER]}
       />
     )
   }

--- a/code/src/store/api/userProfileApi.ts
+++ b/code/src/store/api/userProfileApi.ts
@@ -1,0 +1,15 @@
+import { URLS } from "@/constants/requests";
+import { appApi } from "@/store/api/appApi";
+import { UserResponse } from "@/types/user.types";
+
+export const userProfileApi = appApi.injectEndpoints({
+  endpoints: (build) => ({
+    getUserInfo: build.query<UserResponse, void>({
+      query: () => ({
+        url: URLS.userInfo.getUserInfo
+      })
+    })
+  })
+});
+
+export const { useGetUserInfoQuery } = userProfileApi;

--- a/code/src/store/api/userProfileApi.ts
+++ b/code/src/store/api/userProfileApi.ts
@@ -1,3 +1,4 @@
+import { rtkQueryTags } from "@/constants/api-tags";
 import { URLS } from "@/constants/requests";
 import { appApi } from "@/store/api/appApi";
 import { UserResponse } from "@/types/user.types";
@@ -7,7 +8,8 @@ export const userProfileApi = appApi.injectEndpoints({
     getUserInfo: build.query<UserResponse, void>({
       query: () => ({
         url: URLS.userInfo.getUserInfo
-      })
+      }),
+      providesTags: [rtkQueryTags.USER_PROFILE]
     })
   })
 });

--- a/code/src/types/user.types.ts
+++ b/code/src/types/user.types.ts
@@ -16,6 +16,11 @@ export type User = BaseUser & {
   email: string;
 };
 
+export type UserResponse = User & {
+  phone: string | null;
+  photo: string | null;
+};
+
 export type UserFromServer = BaseUser & {
   sub: string;
   scope: UserRole;

--- a/e2e/cypress/test_module/cypress/features/auth/logout.feature
+++ b/e2e/cypress/test_module/cypress/features/auth/logout.feature
@@ -9,5 +9,5 @@ Feature: | Logout |
     Scenario: Success logout as user
         Given I authenticate to the system under role ROLE_USER
         When I click account icon in header
-        When I click logout from menu
+        And I click logout from menu
         Then I should be logged out

--- a/e2e/cypress/test_module/cypress/features/auth/logout.feature
+++ b/e2e/cypress/test_module/cypress/features/auth/logout.feature
@@ -1,6 +1,13 @@
 Feature: | Logout |
 
-    Scenario: Success logout
-        Given I authenticate to the system under role ROLE_USER
+    Scenario: Success logout as manager
+        Given I authenticate to the system under role ROLE_MANAGER
         When I click logout button
+        Then I should be logged out
+
+
+    Scenario: Success logout as user
+        Given I authenticate to the system under role ROLE_USER
+        When I click account icon in header
+        Then I click logout from menu
         Then I should be logged out

--- a/e2e/cypress/test_module/cypress/features/auth/logout.feature
+++ b/e2e/cypress/test_module/cypress/features/auth/logout.feature
@@ -9,5 +9,5 @@ Feature: | Logout |
     Scenario: Success logout as user
         Given I authenticate to the system under role ROLE_USER
         When I click account icon in header
-        Then I click logout from menu
+        When I click logout from menu
         Then I should be logged out

--- a/e2e/cypress/test_module/cypress/features/home-page/home-page-user.feature
+++ b/e2e/cypress/test_module/cypress/features/home-page/home-page-user.feature
@@ -2,6 +2,7 @@ Feature: | User Home Page |
 
     Scenario: Orders button visibility for login user
         Given I authenticate to the system under role ROLE_USER
+        Then I click account icon in header
         When I can see orders button on a header
         And I click on the orders button
         Then I can see orders page

--- a/e2e/cypress/test_module/cypress/features/home-page/home-page-user.feature
+++ b/e2e/cypress/test_module/cypress/features/home-page/home-page-user.feature
@@ -3,6 +3,6 @@ Feature: | User Home Page |
     Scenario: Orders button visibility for login user
         Given I authenticate to the system under role ROLE_USER
         Then I click account icon in header
-        When I can see orders button on a header
+        When I can see orders button on a header dropdown
         And I click on the orders button
         Then I can see orders page

--- a/e2e/cypress/test_module/cypress/features/home-page/home-page-user.feature
+++ b/e2e/cypress/test_module/cypress/features/home-page/home-page-user.feature
@@ -1,8 +1,9 @@
 Feature: | User Home Page |
 
+    @GS3-34
     Scenario: Orders button visibility for login user
         Given I authenticate to the system under role ROLE_USER
-        Then I click account icon in header
-        When I can see orders button on a header dropdown
+        When I click account icon in header
+        And I can see orders button on a header dropdown
         And I click on the orders button
         Then I can see orders page

--- a/e2e/cypress/test_module/cypress/support/commands.ts
+++ b/e2e/cypress/test_module/cypress/support/commands.ts
@@ -43,7 +43,7 @@ Cypress.Commands.add("loginWithRole", (role = "ROLE_USER") => {
   const email = Cypress.env(`${role}_EMAIL`);
   const password = Cypress.env(`${role}_PASSWORD`);
 
-  cy.intercept("POST", "/api/auth/sign-in").as("loginRequest");
+  cy.intercept("POST", "/retail/auth/sign-in").as("loginRequest");
 
   cy.visitWithLanguage("/");
   cy.getById("auth-button").click();

--- a/e2e/cypress/test_module/cypress/support/step_definitions/home-page-user.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/home-page-user.steps.ts
@@ -2,7 +2,7 @@
 
 import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
 
-When("I can see orders button on a header", () => {
+When("I can see orders button on a header dropdown", () => {
   cy.get('[data-cy="header.orders-item"]').should("be.visible");
 });
 

--- a/e2e/cypress/test_module/cypress/support/step_definitions/home-page-user.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/home-page-user.steps.ts
@@ -3,11 +3,11 @@
 import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
 
 When("I can see orders button on a header", () => {
-  cy.getById("orders-button").should("be.visible");
+  cy.get('[data-cy="header.orders-item"]').should("be.visible");
 });
 
 When("I click on the orders button", () => {
-  cy.getById("orders-button").click();
+  cy.get('[data-cy="header.orders-item"]').click();
 });
 
 Then("I can see orders page", () => {

--- a/e2e/cypress/test_module/cypress/support/step_definitions/logout.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/logout.steps.ts
@@ -10,7 +10,7 @@ When("I click account icon in header", () => {
   cy.get('[data-cy="header-account-button"]').click();
 });
 
-Then("I click logout from menu", () => {
+When("I click logout from menu", () => {
   cy.get('[data-cy="header.logout-item"]').click();
 });
 

--- a/e2e/cypress/test_module/cypress/support/step_definitions/logout.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/logout.steps.ts
@@ -6,6 +6,14 @@ When("I click logout button", () => {
   cy.get("[data-testid='header-logout-button']").click();
 });
 
+When("I click account icon in header", () => {
+  cy.get('[data-cy="header-account-button"]').click();
+});
+
+Then("I click logout from menu", () => {
+  cy.get('[data-cy="header.logout-item"]').click();
+});
+
 Then("I should be logged out", () => {
   cy.getById("auth-button").should("be.visible");
   cy.get("[data-testid='header-logout-button']").should("not.exist");


### PR DESCRIPTION
### Description 

- Added a new **account icon dropdown** in the header using the `AppMenu` component
- Moved **Logout** and **Orders** into the dropdown
- Added **My Profile** option to the dropdown
- Introduced a new route: `/user-cabinet`



https://github.com/user-attachments/assets/c0ede35d-cd74-4b3b-a359-eb0015598ff9

### View with user image:
![image](https://github.com/user-attachments/assets/b521ac4b-7500-4952-978d-264c16f50391)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a user account menu in the header with options for profile, orders, and logout.
  * Added a dedicated user cabinet page accessible to authenticated users.
  * Implemented protected routing for the user cabinet page, restricting access to users with the appropriate role.
  * Added a new app menu component displaying menu items with icons and fallback messaging when no options are available.
  * Integrated user profile photo display in the header account button.

* **Improvements**
  * Updated header localization with new keys for profile, orders, and logout in English and Ukrainian.
  * Enhanced header toolbar to display an account button instead of separate logout and orders buttons.
  * Refined user interface styles for menu dropdown alignment.

* **Bug Fixes**
  * Adjusted test selectors and steps to align with the new account menu structure.

* **Tests**
  * Added and updated tests for the new account menu, header account button, and related header components.
  * Expanded end-to-end tests to cover new logout and orders menu flows for different user roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->