### PR TITLE
[GS3-63] Added missing Like (Heart) Icon for Product on Sale

### DIFF
--- a/code/src/components/product-card/ProductCard.test.tsx
+++ b/code/src/components/product-card/ProductCard.test.tsx
@@ -165,13 +165,6 @@ describe("ProductCard", () => {
       const unfilledHeart = screen.getByTestId("FavoriteBorderIcon");
       expect(unfilledHeart).toBeInTheDocument();
     });
-    
-    test("should call toggle function on favorite button click", () => {
-      const favoriteButton = screen.getByTestId("FavoriteBorderIcon");
-      fireEvent.click(favoriteButton);
-    
-      expect(mockToggle).toHaveBeenCalledWith(mockProduct.id);
-      });
 
     test('should not apply active class when product is not favorite', () => {
       const isProductActiveElement = result.container.querySelector(

--- a/code/src/components/product-card/ProductCard.test.tsx
+++ b/code/src/components/product-card/ProductCard.test.tsx
@@ -31,10 +31,12 @@ const mockToggle = jest.fn();
 
 const renderAndMock = ({
   isProductInCart,
-  isFavorite = false
+  isFavorite = false,
+  product = mockProduct
   }: {
     isProductInCart: boolean;
-    isFavorite: boolean;
+    isFavorite?: boolean;
+    product?: Product;
   }) => {
   (useAddToCartOrOpenDrawer as jest.Mock).mockReturnValue({
     isProductInCart,
@@ -46,7 +48,7 @@ const renderAndMock = ({
     toggle: mockToggle
   });
 
-  return renderWithProviders(<ProductCard product={mockProduct} />);
+  return renderWithProviders(<ProductCard product={product} />);
 };
 
 describe("ProductCard", () => {
@@ -132,28 +134,98 @@ describe("ProductCard", () => {
     });
   });
 
-  describe("favorite button behavior", () => {
-    test("should render unfilled heart icon when product is not favorite", () => {
-      renderAndMock({ isProductInCart: false, isFavorite: false });
-
-      const unfilledHeart = screen.getByTestId("FavoriteBorderIcon");
-      expect(unfilledHeart).toBeInTheDocument();
+  describe("when product is favorite", () => {
+    let result: ReturnType<typeof renderAndMock>;
+  
+    beforeEach(() => {
+      result = renderAndMock({ isProductInCart: false, isFavorite: true });
     });
-
+  
     test("should render filled heart icon when product is favorite", () => {
-      renderAndMock({ isProductInCart: false, isFavorite: true });
-
       const filledHeart = screen.getByTestId("FavoriteIcon");
       expect(filledHeart).toBeInTheDocument();
     });
+    
+    test("should apply active class when product is favorite", () => {
+      const isProductFavoriteElementActive = result.container.querySelector(
+        ".spa-product-card__favorite-button--active"
+      );
+      expect(isProductFavoriteElementActive).toBeInTheDocument();
+    });
+  });
+  
+  describe("when product is not favorite", () => {
+    let result: ReturnType<typeof renderAndMock>;
+  
+    beforeEach(() => {
+      result = renderAndMock({ isProductInCart: false, isFavorite: false });
+    });
+  
+    test("should render unfilled heart icon when product is not favorite", () => {
+      const unfilledHeart = screen.getByTestId("FavoriteBorderIcon");
+      expect(unfilledHeart).toBeInTheDocument();
+    });
+    
+    test("should call toggle function on favorite button click", () => {
+      const favoriteButton = screen.getByTestId("FavoriteBorderIcon");
+      fireEvent.click(favoriteButton);
+    
+      expect(mockToggle).toHaveBeenCalledWith(mockProduct.id);
+      });
+
+    test('should not apply active class when product is not favorite', () => {
+      const isProductActiveElement = result.container.querySelector(
+        ".spa-product-card__favorite-button--active"
+      );
+      expect(isProductActiveElement).not.toBeInTheDocument();
+    });
 
     test("should call toggle function on favorite button click", () => {
-      renderAndMock({ isProductInCart: false, isFavorite: false });
-
       const favoriteButton = screen.getByTestId("FavoriteBorderIcon");
       fireEvent.click(favoriteButton);
 
       expect(mockToggle).toHaveBeenCalledWith(mockProduct.id);
+    });
+  });
+
+  describe("bestsellers block", () => {
+    test("should NOT render bestsellers block when percentageOfTotalOrders is undefined", () => {
+      const productWithoutPercentage = {
+        ...mockProduct,
+        percentageOfTotalOrders: undefined
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithoutPercentage
+      });
+
+      expect(screen.queryByTestId("best-sellers")).not.toBeInTheDocument();
+    });
+
+    test("should NOT render bestsellers block when percentageOfTotalOrders is 0", () => {
+      const productWithZeroPercentage = {
+        ...mockProduct,
+        percentageOfTotalOrders: 0
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithZeroPercentage
+      });
+
+      expect(screen.queryByTestId("best-sellers")).not.toBeInTheDocument();
+    });
+
+    test("should render bestsellers when percentageOfTotalOrders > 0", () => {
+      const product = {
+        ...mockProduct,
+        percentageOfTotalOrders: 20
+      };
+
+      renderAndMock({ isProductInCart: false, product });
+
+      expect(screen.getByTestId("best-sellers")).toBeInTheDocument();
     });
   });
 });

--- a/code/src/components/product-card/ProductCard.tsx
+++ b/code/src/components/product-card/ProductCard.tsx
@@ -84,6 +84,7 @@ const ProductCard = ({ product, isViewHistory = false }: ProductCardProps) => {
               color: "blue"
             }}
             className="spa-product-card__best-sellers"
+            data-testid="best-sellers"
           >
             <AppTypography
               translationKey="bestsellers.title"

--- a/code/src/components/product-sale-card/SaleProductCard.test.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.test.tsx
@@ -4,6 +4,7 @@ import SaleProductCard from "@/components/product-sale-card/SaleProductCard";
 
 import routes from "@/constants/routes";
 import useAddToCartOrOpenDrawer from "@/hooks/use-add-to-cart-or-open-drawer/useAddToCartOrOpenDrawer";
+import useToggleFavorite from "@/hooks/use-toggle-favorite/useToggleFavorite";
 import { Product } from "@/types/product.types";
 import formatPrice from "@/utils/format-price/formatPrice";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
@@ -11,6 +12,10 @@ import renderWithProviders from "@/utils/render-with-providers/renderWithProvide
 const mockAddToCartOrOpenDrawer = jest.fn();
 
 jest.mock("@/hooks/use-add-to-cart-or-open-drawer/useAddToCartOrOpenDrawer");
+
+jest.mock("@/hooks/use-toggle-favorite/useToggleFavorite");
+
+const mockToggle = jest.fn();
 
 const mockProduct: Product = {
   id: "1",
@@ -21,13 +26,26 @@ const mockProduct: Product = {
   status: "AVAILABLE",
   tags: [],
   priceWithDiscount: 80,
-  discount: 20
+  discount: 30
 };
 
-const renderAndMock = (product: Product, isProductInCart: boolean) => {
+const renderAndMock = ({
+  isProductInCart,
+  isFavorite = false,
+  product = mockProduct
+  }: {
+    isProductInCart: boolean;
+    isFavorite?: boolean;
+    product?: Product;
+  }) => {
   (useAddToCartOrOpenDrawer as jest.Mock).mockReturnValue({
     isProductInCart,
     addToCartOrOpenDrawer: mockAddToCartOrOpenDrawer
+  });
+
+  (useToggleFavorite as jest.Mock).mockReturnValue({
+    isFavorite: () => isFavorite,
+    toggle: mockToggle
   });
 
   return renderWithProviders(<SaleProductCard product={product} />);
@@ -42,7 +60,7 @@ describe("SaleProductCard", () => {
     let result: ReturnType<typeof renderAndMock>;
 
     beforeEach(() => {
-      result = renderAndMock(mockProduct, false);
+      result = renderAndMock({ isProductInCart: false });
     });
 
     test("should render product name", () => {
@@ -68,7 +86,10 @@ describe("SaleProductCard", () => {
         priceWithDiscount: undefined
       };
 
-      renderAndMock(productWithoutDiscount, false);
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithoutDiscount
+      });
 
       const discountedPrice = screen.getByText(formatPrice(0));
       expect(discountedPrice).toBeInTheDocument();
@@ -80,7 +101,10 @@ describe("SaleProductCard", () => {
         priceWithDiscount: null
       };
 
-      renderAndMock(productWithNullDiscount, false);
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithNullDiscount
+      });
 
       const discountedPrice = screen.getByText(formatPrice(0));
       expect(discountedPrice).toBeInTheDocument();
@@ -131,7 +155,7 @@ describe("SaleProductCard", () => {
     let result: ReturnType<typeof renderAndMock>;
 
     beforeEach(() => {
-      result = renderAndMock(mockProduct, true);
+      result = renderAndMock({ isProductInCart: true });
     });
 
     test("should render icon with check mark", () => {
@@ -145,6 +169,140 @@ describe("SaleProductCard", () => {
         ".spa-product-card__cart-button--active"
       );
       expect(isProductActiveElement).toBeInTheDocument();
+    });
+  });
+
+  describe("when product is favorite", () => {
+    let result: ReturnType<typeof renderAndMock>;
+
+    beforeEach(() => {
+      result = renderAndMock({ isProductInCart: false, isFavorite: true });
+    });
+
+    test("should render filled heart icon when product is favorite", () => {
+      const filledHeart = screen.getByTestId("FavoriteIcon");
+      expect(filledHeart).toBeInTheDocument();
+    });
+  
+    test("should apply active class when product is favorite", () => {
+      const isProductFavoriteElementActive = result.container.querySelector(
+        ".spa-product-card__favorite-button--active"
+      );
+      expect(isProductFavoriteElementActive).toBeInTheDocument();
+    });
+  });
+
+  describe("when product is not favorite", () => {
+    let result: ReturnType<typeof renderAndMock>;
+
+    beforeEach(() => {
+      result = renderAndMock({ isProductInCart: false, isFavorite: false });
+    });
+
+    test("should render unfilled heart icon when product is not favorite", () => {
+      const unfilledHeart = screen.getByTestId("FavoriteBorderIcon");
+      expect(unfilledHeart).toBeInTheDocument();
+    });
+  
+
+    test("should call toggle function on favorite button click", () => {
+      const favoriteButton = screen.getByTestId("FavoriteBorderIcon");
+      fireEvent.click(favoriteButton);
+  
+      expect(mockToggle).toHaveBeenCalledWith(mockProduct.id);
+    });
+    test('should not apply active class when product is not favorite', () => {
+      const isProductActiveElement = result.container.querySelector(
+        ".spa-product-card__favorite-button--active"
+      );
+      expect(isProductActiveElement).not.toBeInTheDocument();
+    });
+  });
+
+  describe("discount percentage display", () => {
+    test("should render discount label when discount percentage is greater than 0", () => {
+      const discountedProduct = {
+        ...mockProduct,
+        price: 100,
+        priceWithDiscount: 70
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: discountedProduct
+      });
+
+      expect(screen.getByTestId("discount-label")).toHaveTextContent("-30%");
+    });
+
+    test("should NOT render discount label when discount percentage is 0", () => {
+      const noDiscountProduct = {
+        ...mockProduct,
+        price: 100,
+        priceWithDiscount: 100
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: noDiscountProduct
+      });
+
+      expect(screen.queryByText(/-%/)).not.toBeInTheDocument();
+    });
+
+    test("should NOT render discount label when priceWithDiscount is missing", () => {
+      const undefinedDiscountProduct = {
+        ...mockProduct,
+        priceWithDiscount: undefined
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: undefinedDiscountProduct
+      });
+
+      expect(screen.queryByText(/-%/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("bestsellers block", () => {
+    test("should NOT render bestsellers block when percentageOfTotalOrders is undefined", () => {
+      const productWithoutPercentage = {
+        ...mockProduct,
+        percentageOfTotalOrders: undefined
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithoutPercentage
+      });
+
+      expect(screen.queryByTestId("best-sellers")).not.toBeInTheDocument();
+    });
+
+    test("should NOT render bestsellers block when percentageOfTotalOrders is 0", () => {
+      const productWithZeroPercentage = {
+        ...mockProduct,
+        percentageOfTotalOrders: 0
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithZeroPercentage
+      });
+
+      expect(screen.queryByTestId("best-sellers")).not.toBeInTheDocument();
+    });
+
+    test("should render bestsellers when percentageOfTotalOrders > 0", () => {
+      const product = {
+        ...mockProduct,
+        percentageOfTotalOrders: 20
+      };
+
+      renderAndMock({ isProductInCart: false, product });
+
+      expect(screen.getByTestId("best-sellers")).toBeInTheDocument();
     });
   });
 });

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -62,7 +62,12 @@ const SaleProductCard = ({
       className="spa-product-card spa-sale-product-card"
       data-cy="product-card"
     >
-      <AppBox className="spa-sale-product-card__label">-{discount}%</AppBox>
+      <AppBox
+        className="spa-sale-product-card__label"
+        data-testid="discount-label"
+        >
+        -{discount}%
+      </AppBox>
       <AppLink
         className="spa-product-card__link-wrapper"
         to={routePaths.productDetails.path(id)}
@@ -96,6 +101,7 @@ const SaleProductCard = ({
               color: "blue"
             }}
             className="spa-product-card__best-sellers"
+            data-testid="best-sellers"
           >
             <AppTypography
               translationKey="bestsellers.title"

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
 
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+
 import AppBox from "@/components/app-box/AppBox";
 import AppIconButton from "@/components/app-icon-button/AppIconButton";
 import AppLink from "@/components/app-link/AppLink";
@@ -11,6 +14,7 @@ import cartIconWithPlus from "@/assets/icons/cart-with-plus.svg";
 import fallbackImage from "@/assets/images/default-product-image.png";
 import routePaths from "@/constants/routes";
 import useAddToCartOrOpenDrawer from "@/hooks/use-add-to-cart-or-open-drawer/useAddToCartOrOpenDrawer";
+import useToggleFavorite from "@/hooks/use-toggle-favorite/useToggleFavorite";
 import cn from "@/utils/cn/cn";
 import formatPrice from "@/utils/format-price/formatPrice";
 
@@ -37,9 +41,15 @@ const SaleProductCard = ({
   const roundedPercentage = Math.round(percentageOfTotalOrders || 0);
 
   const [imgSrc, setImgSrc] = useState(image);
+  const { toggle, isFavorite } = useToggleFavorite();
 
   const handleImageError = () => {
     setImgSrc(fallbackImage);
+  };
+
+  const handleFavoriteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    toggle(product.id);
   };
 
   const cartIconId = isProductInCart ? "cart-with-check" : "cart-with-plus";
@@ -115,18 +125,34 @@ const SaleProductCard = ({
             {formatPrice(priceWithDiscount ?? 0)}
           </AppTypography>
         </AppBox>
-        <AppIconButton
-          data-cy="add-to-cart-button"
-          onClick={addToCartOrOpenDrawer}
-          className={cn(
-            "spa-product-card__cart-button",
-            isProductInCart && "spa-product-card__cart-button--active"
-          )}
-        >
-          <svg>
-            <use data-testid="add-to-cart-icon" href={cartIconFullLink} />
-          </svg>
-        </AppIconButton>
+        <AppBox className="spa-product-card__footer-buttons">
+          <AppIconButton
+            data-cy="favorite-button"
+            onClick={handleFavoriteClick}
+            className={cn(
+              "spa-product-card__favorite-button",
+              isFavorite(product.id) && "spa-product-card__favorite-button--active"
+            )}
+          >
+            {isFavorite(product.id) ? (
+              <FavoriteIcon fontSize="small" />
+            ) : (
+              <FavoriteBorderIcon fontSize="small" />
+            )}
+          </AppIconButton>
+          <AppIconButton
+            data-cy="add-to-cart-button"
+            onClick={addToCartOrOpenDrawer}
+            className={cn(
+              "spa-product-card__cart-button",
+              isProductInCart && "spa-product-card__cart-button--active"
+            )}
+          >
+            <svg>
+              <use data-testid="add-to-cart-icon" href={cartIconFullLink} />
+            </svg>
+          </AppIconButton>
+        </AppBox>
       </AppBox>
     </AppBox>
   );

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.module.scss
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.module.scss
@@ -7,10 +7,6 @@
   display: flex;
   flex-direction: column;
 
-  &_grid {
-    margin-top: 16px;
-  }
-
   &_emptyMessage {
     display: flex;
     justify-content: center;
@@ -36,5 +32,18 @@
 
   &_sort {
     cursor: pointer;
+  }
+
+  &_productsGrid {
+    margin-top: spacing(4);
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    justify-content: flex-start;
+    width: 100%;
+    gap: spacing(16);
+
+    & > * {
+      width: 280px;
+    }
   }
 }

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
@@ -86,7 +86,7 @@ const MyWishlist = () => {
         />
       )}
       <ProductsContainer
-        className="spa-my-wishlist__grid"
+        className={styles.MyWishlist_productsGrid}
         products={productsList ?? []}
         isLoading={isLoading}
         loadingItemsCount={10}


### PR DESCRIPTION
* Added missing Like (Heart) Icon for Product on Sale card 
* Fixed relevant styles on the pages 'All Products', 'Computers', etc.

Before:
<img width="242" height="378" alt="Image" src="https://github.com/user-attachments/assets/c30ff23d-8c25-4251-ab01-9053bbe7e9e2" />

After:
<img width="242" height="378" alt="image" src="https://github.com/user-attachments/assets/3bf2d1f6-9bed-49f7-bde9-16d40468825d" />

* Fixed styles of Product Cards in `My Wishlist` section of `My Profile` page
<img width="1743" height="860" alt="image" src="https://github.com/user-attachments/assets/ef59c9e2-ade0-457b-b298-53b527eda67e" />

* Added new test for `SaleProductCard` and `ProductCard`. Stryker results:
<img width="865" height="194" alt="image" src="https://github.com/user-attachments/assets/0bafe626-cb82-442e-b905-f76a237d465e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a favorite toggle button to sale product cards, allowing users to mark products as favorites.
  * Favorite status is visually indicated with filled or outlined heart icons.

* **Bug Fixes**
  * Improved display logic for discount labels and bestsellers badges on product cards.

* **Style**
  * Updated wishlist product grid layout for a more structured and visually appealing arrangement.

* **Tests**
  * Expanded and refactored tests to cover favorite toggling, discount labels, and bestsellers badge logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->