### PR TITLE
[GS3-67] Added modal confirmation for clear all history

### DIFF
--- a/code/src/components/app-button/AppButton.scss
+++ b/code/src/components/app-button/AppButton.scss
@@ -101,7 +101,7 @@
   &__danger {
     @include focus-style(var(--spa-button-danger-focus-color, $red));
     @include hover-effect(
-      var(--spa-button-danger--bg-hover-color, $white),
+      var(--color-surface),
       var(--spa-button-danger--text-hover-color, $red)
     );
 

--- a/code/src/containers/modals/confirm-modal/ConfirmModal.module.scss
+++ b/code/src/containers/modals/confirm-modal/ConfirmModal.module.scss
@@ -10,11 +10,14 @@
   flex-direction: column;
   gap: spacing(3);
   position: relative;
+  color: var(--color-text);
+  background-color: var(--color-surface);
 
   &_closeIcon {
     position: absolute;
     top: spacing(2);
     right: spacing(2);
     cursor: pointer;
+    color: inherit;
   }
 }

--- a/code/src/containers/modals/confirm-modal/ConfirmModal.module.scss
+++ b/code/src/containers/modals/confirm-modal/ConfirmModal.module.scss
@@ -1,0 +1,20 @@
+@import "@design-system";
+
+.confirmModal {
+  width: 30vw;
+  max-width: 90vw;
+  height: auto;
+  max-height: 90vh;
+  padding: spacing(7);
+  display: flex;
+  flex-direction: column;
+  gap: spacing(3);
+  position: relative;
+
+  &_closeIcon {
+    position: absolute;
+    top: spacing(2);
+    right: spacing(2);
+    cursor: pointer;
+  }
+}

--- a/code/src/containers/modals/confirm-modal/ConfirmModal.test.tsx
+++ b/code/src/containers/modals/confirm-modal/ConfirmModal.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+
+import userEvent from "@testing-library/user-event";
+
+import ConfirmModal from "./ConfirmModal";
+
+const mockedCloseModal = jest.fn();
+const mockedSaveModal = jest.fn();
+
+const mockedDescription = "some description";
+const renderAndMock = (
+  description?: string,
+  textSave?: string,
+  textCancel?: string
+) => {
+  return render(
+    <ConfirmModal
+      title="title"
+      description={description}
+      onCancel={mockedCloseModal}
+      onSave={mockedSaveModal}
+      textSave={textSave}
+      textCancel={textCancel}
+    />
+  );
+};
+
+describe("ConfirmModal", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should render Modal with title and default buttons name", () => {
+    renderAndMock();
+
+    const title = screen.getByText("title");
+    const saveBtn = screen.getByText("confirmModal.saveButton");
+    const closeBtn = screen.getByText("confirmModal.closeButton");
+
+    expect(title).toBeInTheDocument();
+    expect(saveBtn).toBeInTheDocument();
+    expect(closeBtn).toBeInTheDocument();
+  });
+
+  it("should render Modal with description", () => {
+    renderAndMock(mockedDescription);
+
+    const description = screen.getByText(mockedDescription);
+
+    expect(description.innerHTML).toBe(mockedDescription);
+    expect(description.tagName.toLowerCase()).toBe("p");
+  });
+
+  it("should invoke save and close modal", async () => {
+    renderAndMock();
+
+    const saveBtn = screen.getByText("confirmModal.saveButton");
+    await userEvent.click(saveBtn);
+
+    expect(mockedSaveModal).toHaveBeenCalled();
+    expect(mockedCloseModal).toHaveBeenCalled();
+  });
+
+  it("should close modal by cancel button", async () => {
+    renderAndMock();
+
+    const closeBtn = screen.getByText("confirmModal.closeButton");
+    await userEvent.click(closeBtn);
+
+    expect(mockedCloseModal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/code/src/containers/modals/confirm-modal/ConfirmModal.tsx
+++ b/code/src/containers/modals/confirm-modal/ConfirmModal.tsx
@@ -1,0 +1,66 @@
+import CloseIcon from "@mui/icons-material/Close";
+import { Dialog, DialogActions } from "@mui/material";
+
+import AppButton from "@/components/app-button/AppButton";
+import AppIconButton from "@/components/app-icon-button/AppIconButton";
+import AppTypography from "@/components/app-typography/AppTypography";
+
+import * as styles from "@/containers/modals/confirm-modal/ConfirmModal.module.scss";
+
+interface ConfirmModalProps {
+  title: string;
+  description?: string;
+  onCancel: () => void;
+  onSave: () => void;
+  textSave?: string;
+  textCancel?: string;
+}
+
+const ConfirmModal = ({
+  onCancel,
+  title,
+  description,
+  onSave,
+  textSave = "confirmModal.saveButton",
+  textCancel = "confirmModal.closeButton"
+}: ConfirmModalProps) => {
+  const handleClose = () => {
+    onCancel();
+  };
+
+  const handleSave = () => {
+    onSave();
+    onCancel();
+  };
+
+  return (
+    <Dialog
+      open={true}
+      onClose={handleClose}
+      PaperProps={{
+        className: styles.confirmModal,
+        "data-testid": "confirm-modal-paper"
+      }}
+    >
+      <AppTypography variant="h3" translationKey={title} />
+      <AppIconButton
+        className={styles.confirmModal_closeIcon}
+        data-testid="close-modal"
+        onClick={handleClose}
+      >
+        <CloseIcon />
+      </AppIconButton>
+      {description && <AppTypography translationKey={description} />}
+      <DialogActions>
+        <AppButton onClick={handleClose} variant="danger">
+          <AppTypography translationKey={textCancel} />
+        </AppButton>
+        <AppButton onClick={handleSave}>
+          <AppTypography translationKey={textSave} />
+        </AppButton>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmModal;

--- a/code/src/containers/modals/confirm-modal/messages/en.json
+++ b/code/src/containers/modals/confirm-modal/messages/en.json
@@ -1,0 +1,4 @@
+{
+  "confirmModal.saveButton": "Save",
+  "confirmModal.closeButton": "Close"
+}

--- a/code/src/containers/modals/confirm-modal/messages/index.ts
+++ b/code/src/containers/modals/confirm-modal/messages/index.ts
@@ -1,0 +1,4 @@
+import en from "@/containers/modals/confirm-modal/messages/en.json";
+import uk from "@/containers/modals/confirm-modal/messages/uk.json";
+
+export default { en, uk };

--- a/code/src/containers/modals/confirm-modal/messages/uk.json
+++ b/code/src/containers/modals/confirm-modal/messages/uk.json
@@ -1,0 +1,4 @@
+{
+  "confirmModal.saveButton": "Зберегти",
+  "confirmModal.closeButton": "Закрити"
+}

--- a/code/src/containers/user-account/view-history/UserViewHistory.test.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 
 import userEvent from "@testing-library/user-event";
 
+import { useModalContext } from "@/context/modal/ModalContext";
 import { RedirectConfig } from "@/hooks/use-error-page-redirect/useErrorPageRedirect.types";
 import {
   useDeleteAllViewProductsMutation,
@@ -27,11 +28,25 @@ const deleteAllViewProductsMock = jest.fn();
 
 const mockSetSearchParams = jest.fn();
 const mockSearchParams = new URLSearchParams();
+const mockedModalOpen = jest.fn();
+const mockedModalClose = jest.fn();
+
 const mockRedirect = ({
   errorMessageTranslationKey
 }: Pick<RedirectConfig, "errorMessageTranslationKey">) => (
   <div>{errorMessageTranslationKey}</div>
 );
+jest.mock("@/containers/modals/confirm-modal/ConfirmModal", () => ({
+  __esModule: true,
+  default: () => {
+    return (
+      <div id="confirm-modal">
+        <button>cancel</button>
+        <button>save</button>
+      </div>
+    );
+  }
+}));
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useSearchParams: () => [mockSearchParams, mockSetSearchParams]
@@ -47,6 +62,11 @@ jest.mock("@/context/i18n/I18nProvider", () => ({
 jest.mock("@/hooks/use-error-page-redirect/useErrorPageRedirect", () => ({
   __esModule: true,
   default: jest.fn(() => ({ renderRedirectComponent: mockRedirect }))
+}));
+
+jest.mock("@/context/modal/ModalContext", () => ({
+  ...jest.requireActual("@/context/modal/ModalContext"),
+  useModalContext: jest.fn()
 }));
 
 jest.mock("@/containers/products-container/ProductsContainer", () => ({
@@ -87,7 +107,10 @@ const renderAndMock = ({
   (useDeleteAllViewProductsMutation as jest.Mock).mockReturnValue([
     deleteAllViewProductsMock
   ]);
-
+  (useModalContext as jest.Mock).mockReturnValue({
+    openModal: mockedModalOpen,
+    closeModal: mockedModalClose
+  });
   (useGetViewHistoryApiQuery as jest.Mock).mockReturnValue({
     isLoading,
     isError,
@@ -125,14 +148,14 @@ describe("UserViewHistory", () => {
     expect(skeletons.length).toBe(10);
   });
 
-  it("should call deleteAllViewProducts when button is clicked", async () => {
+  it("should call clearAll and open modal", async () => {
     renderAndMock();
 
     const deleteButton = screen.getByText("userViewHistory.clearAll");
 
     await userEvent.click(deleteButton);
 
-    expect(deleteAllViewProductsMock).toHaveBeenCalled();
+    expect(mockedModalOpen).toHaveBeenCalled();
   });
 
   it("should set sort param when handleSortChange is called", async () => {

--- a/code/src/containers/user-account/view-history/UserViewHistory.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.tsx
@@ -2,6 +2,7 @@ import { useSearchParams } from "react-router-dom";
 
 import SentimentDissatisfiedOutlinedIcon from "@mui/icons-material/SentimentDissatisfiedOutlined";
 
+import ConfirmModal from "@/containers/modals/confirm-modal/ConfirmModal";
 import PaginationBlock from "@/containers/pagination-block/PaginationBlock";
 import ProductsContainer from "@/containers/products-container/ProductsContainer";
 import {
@@ -16,6 +17,7 @@ import AppTypography from "@/components/app-typography/AppTypography";
 import ProductSkeleton from "@/components/product-skeleton/ProductSkeleton";
 
 import { useLocaleContext } from "@/context/i18n/I18nProvider";
+import { useModalContext } from "@/context/modal/ModalContext";
 import useErrorPageRedirect from "@/hooks/use-error-page-redirect/useErrorPageRedirect";
 import usePagination from "@/hooks/use-pagination/usePagination";
 import {
@@ -37,6 +39,7 @@ const UserViewHistory = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const sortOption = searchParams.get("sort");
   const { renderRedirectComponent } = useErrorPageRedirect();
+  const { openModal, closeModal } = useModalContext();
 
   const [deleteAllViewProducts] = useDeleteAllViewProductsMutation();
   const {
@@ -54,7 +57,15 @@ const UserViewHistory = () => {
   const pagesCount = viewHistoryResponse?.totalPages ?? 1;
 
   const onDeleteAll = () => {
-    deleteAllViewProducts();
+    openModal(
+      <ConfirmModal
+        title="userViewHistory.confirmModal.title"
+        description="userViewHistory.confirmModal.description"
+        onCancel={closeModal}
+        onSave={deleteAllViewProducts}
+        textSave="userViewHistory.confirmModal.clearButton"
+      />
+    );
   };
 
   const handleSortChange = (value: string) => {
@@ -138,10 +149,7 @@ const UserViewHistory = () => {
         />
       </AppBox>
       {content()}
-      <PaginationBlock
-        page={page}
-        totalPages={pagesCount}
-      />
+      <PaginationBlock page={page} totalPages={pagesCount} />
     </AppBox>
   );
 };

--- a/code/src/containers/user-account/view-history/messages/en.json
+++ b/code/src/containers/user-account/view-history/messages/en.json
@@ -3,7 +3,7 @@
   "userViewHistory.clearAll": "Clear all",
   "userViewHistory.noProducts": "No viewed products",
   "sortOptions.oldest": "Oldest",
-  "userViewHistory.userViewHistory.productsLabel": "{count, plural, one {# viewed product} other {# viewed products}}",
+  "userViewHistory.productsLabel": "{count, plural, one {# viewed product} other {# viewed products}}",
   "userViewHistory.confirmModal.title": "Clear all items?",
   "userViewHistory.confirmModal.description": "This action will remove all items. Are you sure you want to continue?",
   "userViewHistory.confirmModal.clearButton": "Clear"

--- a/code/src/containers/user-account/view-history/messages/en.json
+++ b/code/src/containers/user-account/view-history/messages/en.json
@@ -3,5 +3,8 @@
   "userViewHistory.clearAll": "Clear all",
   "userViewHistory.noProducts": "No viewed products",
   "sortOptions.oldest": "Oldest",
-  "userViewHistory.productsLabel": "{count, plural, one {# viewed product} other {# viewed products}}"
+  "userViewHistory.userViewHistory.productsLabel": "{count, plural, one {# viewed product} other {# viewed products}}",
+  "userViewHistory.confirmModal.title": "Clear all items?",
+  "userViewHistory.confirmModal.description": "This action will remove all items. Are you sure you want to continue?",
+  "userViewHistory.confirmModal.clearButton": "Clear"
 }

--- a/code/src/containers/user-account/view-history/messages/uk.json
+++ b/code/src/containers/user-account/view-history/messages/uk.json
@@ -3,5 +3,8 @@
   "userViewHistory.clearAll": "Очистити всі",
   "userViewHistory.noProducts": "Немає переглянутого товарів",
   "userViewHistory.productsLabel": "{count, plural, one {# переглянутий товар} other {# переглянутих товарів}}",
-  "sortOptions.oldest": "Старі"
+  "sortOptions.oldest": "Старі",
+  "userViewHistory.confirmModal.title": "Очистити всі елементи?",
+  "userViewHistory.confirmModal.description": "Ця дія видалить усі елементи. Ви впевнені, що хочете продовжити?",
+  "userViewHistory.confirmModal.clearButton": "Очистити"
 }

--- a/code/src/messages.ts
+++ b/code/src/messages.ts
@@ -14,21 +14,22 @@ import signInFormMessages from "@/containers/forms/sign-in-form/messages";
 import signupFormMessages from "@/containers/forms/sign-up-form/messages";
 import bannerMessages from "@/containers/intro-banner/messages";
 import authModalMessages from "@/containers/modals/auth/messages";
+import confirmModalMessages from "@/containers/modals/confirm-modal/messages";
 import editPersonalInfoMessages from "@/containers/modals/user-account/messages";
 import orderItemMessages from "@/containers/order-item/messages";
 import subintroMessages from "@/containers/subintro/messages";
 import ordersTableMessages from "@/containers/tables/orders-table/messages";
 import productsTableMessages from "@/containers/tables/products-table/messages";
 import usersTableMessages from "@/containers/tables/users-table/messages";
-import userViewHistoryMessages from "@/containers/user-account/view-history/messages";
 import myWishlistMessages from "@/containers/user-account/my-wishlist/messages";
 import profileMessages from "@/containers/user-account/profile/messages";
+import userViewHistoryMessages from "@/containers/user-account/view-history/messages";
 
 import dropDownMessages from "@/components/app-dropdown/messages";
 import bestSellerContainerMessages from "@/components/bestseller-card/messages";
 import productCardMessages from "@/components/product-card/messages";
-import sidebar from "@/components/sidebar/messages";
 import PersonalInformation from "@/components/profile-personal-information/messages";
+import sidebar from "@/components/sidebar/messages";
 
 import commonMessages from "@/constants/common-messages";
 import { Locale } from "@/context/i18n/I18nProvider";
@@ -98,6 +99,7 @@ const messages: MessagesType = {
     ...PersonalInformation.en,
     ...myWishlistMessages.en,
     ...profileMessages.en,
+    ...confirmModalMessages.en
   },
   uk: {
     ...commonMessages.uk,
@@ -142,10 +144,11 @@ const messages: MessagesType = {
     ...dashboardMetricsPageMessages.uk,
     ...sidebar.uk,
     ...editPersonalInfoMessages.uk,
-     ...userViewHistoryMessages.uk,
+    ...userViewHistoryMessages.uk,
     ...PersonalInformation.uk,
     ...myWishlistMessages.uk,
     ...profileMessages.uk,
+    ...confirmModalMessages.uk
   }
 };
 


### PR DESCRIPTION
### Description

Implemented a confirmation window before `Clear All` history

https://github.com/user-attachments/assets/4a69994c-6c1f-4fe0-97d6-4282640ea5c1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a confirmation modal when clearing all viewed products in user view history, requiring user approval before deletion.
  * Added a reusable confirmation modal component with customizable title, description, and button labels.

* **Localization**
  * Added English and Ukrainian translations for confirmation modal button labels and user view history modal messages.

* **Bug Fixes**
  * Updated tests to verify the new confirmation modal workflow before deleting viewed products.

* **Style**
  * Added new styles for the confirmation modal, including responsive layout and interactive close icon.
  * Updated hover background color for danger buttons for improved visual consistency.

* **Tests**
  * Added tests for the confirmation modal component to ensure correct rendering and callback behavior.
  * Updated user view history tests to reflect the new confirmation modal flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->