### PR TITLE
[GS3-64] Added missing Like (Favorite) Icon for Product details page

### DIFF
--- a/code/src/components/product-card/ProductCard.test.tsx
+++ b/code/src/components/product-card/ProductCard.test.tsx
@@ -31,10 +31,12 @@ const mockToggle = jest.fn();
 
 const renderAndMock = ({
   isProductInCart,
-  isFavorite = false
+  isFavorite = false,
+  product = mockProduct
   }: {
     isProductInCart: boolean;
-    isFavorite: boolean;
+    isFavorite?: boolean;
+    product?: Product;
   }) => {
   (useAddToCartOrOpenDrawer as jest.Mock).mockReturnValue({
     isProductInCart,
@@ -46,7 +48,7 @@ const renderAndMock = ({
     toggle: mockToggle
   });
 
-  return renderWithProviders(<ProductCard product={mockProduct} />);
+  return renderWithProviders(<ProductCard product={product} />);
 };
 
 describe("ProductCard", () => {
@@ -132,28 +134,98 @@ describe("ProductCard", () => {
     });
   });
 
-  describe("favorite button behavior", () => {
-    test("should render unfilled heart icon when product is not favorite", () => {
-      renderAndMock({ isProductInCart: false, isFavorite: false });
-
-      const unfilledHeart = screen.getByTestId("FavoriteBorderIcon");
-      expect(unfilledHeart).toBeInTheDocument();
+  describe("when product is favorite", () => {
+    let result: ReturnType<typeof renderAndMock>;
+  
+    beforeEach(() => {
+      result = renderAndMock({ isProductInCart: false, isFavorite: true });
     });
-
+  
     test("should render filled heart icon when product is favorite", () => {
-      renderAndMock({ isProductInCart: false, isFavorite: true });
-
       const filledHeart = screen.getByTestId("FavoriteIcon");
       expect(filledHeart).toBeInTheDocument();
     });
+    
+    test("should apply active class when product is favorite", () => {
+      const isProductFavoriteElementActive = result.container.querySelector(
+        ".spa-product-card__favorite-button--active"
+      );
+      expect(isProductFavoriteElementActive).toBeInTheDocument();
+    });
+  });
+  
+  describe("when product is not favorite", () => {
+    let result: ReturnType<typeof renderAndMock>;
+  
+    beforeEach(() => {
+      result = renderAndMock({ isProductInCart: false, isFavorite: false });
+    });
+  
+    test("should render unfilled heart icon when product is not favorite", () => {
+      const unfilledHeart = screen.getByTestId("FavoriteBorderIcon");
+      expect(unfilledHeart).toBeInTheDocument();
+    });
+    
+    test("should call toggle function on favorite button click", () => {
+      const favoriteButton = screen.getByTestId("FavoriteBorderIcon");
+      fireEvent.click(favoriteButton);
+    
+      expect(mockToggle).toHaveBeenCalledWith(mockProduct.id);
+      });
+
+    test('should not apply active class when product is not favorite', () => {
+      const isProductActiveElement = result.container.querySelector(
+        ".spa-product-card__favorite-button--active"
+      );
+      expect(isProductActiveElement).not.toBeInTheDocument();
+    });
 
     test("should call toggle function on favorite button click", () => {
-      renderAndMock({ isProductInCart: false, isFavorite: false });
-
       const favoriteButton = screen.getByTestId("FavoriteBorderIcon");
       fireEvent.click(favoriteButton);
 
       expect(mockToggle).toHaveBeenCalledWith(mockProduct.id);
+    });
+  });
+
+  describe("bestsellers block", () => {
+    test("should NOT render bestsellers block when percentageOfTotalOrders is undefined", () => {
+      const productWithoutPercentage = {
+        ...mockProduct,
+        percentageOfTotalOrders: undefined
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithoutPercentage
+      });
+
+      expect(screen.queryByTestId("best-sellers")).not.toBeInTheDocument();
+    });
+
+    test("should NOT render bestsellers block when percentageOfTotalOrders is 0", () => {
+      const productWithZeroPercentage = {
+        ...mockProduct,
+        percentageOfTotalOrders: 0
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithZeroPercentage
+      });
+
+      expect(screen.queryByTestId("best-sellers")).not.toBeInTheDocument();
+    });
+
+    test("should render bestsellers when percentageOfTotalOrders > 0", () => {
+      const product = {
+        ...mockProduct,
+        percentageOfTotalOrders: 20
+      };
+
+      renderAndMock({ isProductInCart: false, product });
+
+      expect(screen.getByTestId("best-sellers")).toBeInTheDocument();
     });
   });
 });

--- a/code/src/components/product-card/ProductCard.tsx
+++ b/code/src/components/product-card/ProductCard.tsx
@@ -84,6 +84,7 @@ const ProductCard = ({ product, isViewHistory = false }: ProductCardProps) => {
               color: "blue"
             }}
             className="spa-product-card__best-sellers"
+            data-testid="best-sellers"
           >
             <AppTypography
               translationKey="bestsellers.title"

--- a/code/src/components/product-sale-card/SaleProductCard.test.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.test.tsx
@@ -4,6 +4,7 @@ import SaleProductCard from "@/components/product-sale-card/SaleProductCard";
 
 import routes from "@/constants/routes";
 import useAddToCartOrOpenDrawer from "@/hooks/use-add-to-cart-or-open-drawer/useAddToCartOrOpenDrawer";
+import useToggleFavorite from "@/hooks/use-toggle-favorite/useToggleFavorite";
 import { Product } from "@/types/product.types";
 import formatPrice from "@/utils/format-price/formatPrice";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
@@ -11,6 +12,10 @@ import renderWithProviders from "@/utils/render-with-providers/renderWithProvide
 const mockAddToCartOrOpenDrawer = jest.fn();
 
 jest.mock("@/hooks/use-add-to-cart-or-open-drawer/useAddToCartOrOpenDrawer");
+
+jest.mock("@/hooks/use-toggle-favorite/useToggleFavorite");
+
+const mockToggle = jest.fn();
 
 const mockProduct: Product = {
   id: "1",
@@ -21,13 +26,26 @@ const mockProduct: Product = {
   status: "AVAILABLE",
   tags: [],
   priceWithDiscount: 80,
-  discount: 20
+  discount: 30
 };
 
-const renderAndMock = (product: Product, isProductInCart: boolean) => {
+const renderAndMock = ({
+  isProductInCart,
+  isFavorite = false,
+  product = mockProduct
+  }: {
+    isProductInCart: boolean;
+    isFavorite?: boolean;
+    product?: Product;
+  }) => {
   (useAddToCartOrOpenDrawer as jest.Mock).mockReturnValue({
     isProductInCart,
     addToCartOrOpenDrawer: mockAddToCartOrOpenDrawer
+  });
+
+  (useToggleFavorite as jest.Mock).mockReturnValue({
+    isFavorite: () => isFavorite,
+    toggle: mockToggle
   });
 
   return renderWithProviders(<SaleProductCard product={product} />);
@@ -42,7 +60,7 @@ describe("SaleProductCard", () => {
     let result: ReturnType<typeof renderAndMock>;
 
     beforeEach(() => {
-      result = renderAndMock(mockProduct, false);
+      result = renderAndMock({ isProductInCart: false });
     });
 
     test("should render product name", () => {
@@ -68,7 +86,10 @@ describe("SaleProductCard", () => {
         priceWithDiscount: undefined
       };
 
-      renderAndMock(productWithoutDiscount, false);
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithoutDiscount
+      });
 
       const discountedPrice = screen.getByText(formatPrice(0));
       expect(discountedPrice).toBeInTheDocument();
@@ -80,7 +101,10 @@ describe("SaleProductCard", () => {
         priceWithDiscount: null
       };
 
-      renderAndMock(productWithNullDiscount, false);
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithNullDiscount
+      });
 
       const discountedPrice = screen.getByText(formatPrice(0));
       expect(discountedPrice).toBeInTheDocument();
@@ -131,7 +155,7 @@ describe("SaleProductCard", () => {
     let result: ReturnType<typeof renderAndMock>;
 
     beforeEach(() => {
-      result = renderAndMock(mockProduct, true);
+      result = renderAndMock({ isProductInCart: true });
     });
 
     test("should render icon with check mark", () => {
@@ -145,6 +169,140 @@ describe("SaleProductCard", () => {
         ".spa-product-card__cart-button--active"
       );
       expect(isProductActiveElement).toBeInTheDocument();
+    });
+  });
+
+  describe("when product is favorite", () => {
+    let result: ReturnType<typeof renderAndMock>;
+
+    beforeEach(() => {
+      result = renderAndMock({ isProductInCart: false, isFavorite: true });
+    });
+
+    test("should render filled heart icon when product is favorite", () => {
+      const filledHeart = screen.getByTestId("FavoriteIcon");
+      expect(filledHeart).toBeInTheDocument();
+    });
+  
+    test("should apply active class when product is favorite", () => {
+      const isProductFavoriteElementActive = result.container.querySelector(
+        ".spa-product-card__favorite-button--active"
+      );
+      expect(isProductFavoriteElementActive).toBeInTheDocument();
+    });
+  });
+
+  describe("when product is not favorite", () => {
+    let result: ReturnType<typeof renderAndMock>;
+
+    beforeEach(() => {
+      result = renderAndMock({ isProductInCart: false, isFavorite: false });
+    });
+
+    test("should render unfilled heart icon when product is not favorite", () => {
+      const unfilledHeart = screen.getByTestId("FavoriteBorderIcon");
+      expect(unfilledHeart).toBeInTheDocument();
+    });
+  
+
+    test("should call toggle function on favorite button click", () => {
+      const favoriteButton = screen.getByTestId("FavoriteBorderIcon");
+      fireEvent.click(favoriteButton);
+  
+      expect(mockToggle).toHaveBeenCalledWith(mockProduct.id);
+    });
+    test('should not apply active class when product is not favorite', () => {
+      const isProductActiveElement = result.container.querySelector(
+        ".spa-product-card__favorite-button--active"
+      );
+      expect(isProductActiveElement).not.toBeInTheDocument();
+    });
+  });
+
+  describe("discount percentage display", () => {
+    test("should render discount label when discount percentage is greater than 0", () => {
+      const discountedProduct = {
+        ...mockProduct,
+        price: 100,
+        priceWithDiscount: 70
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: discountedProduct
+      });
+
+      expect(screen.getByTestId("discount-label")).toHaveTextContent("-30%");
+    });
+
+    test("should NOT render discount label when discount percentage is 0", () => {
+      const noDiscountProduct = {
+        ...mockProduct,
+        price: 100,
+        priceWithDiscount: 100
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: noDiscountProduct
+      });
+
+      expect(screen.queryByText(/-%/)).not.toBeInTheDocument();
+    });
+
+    test("should NOT render discount label when priceWithDiscount is missing", () => {
+      const undefinedDiscountProduct = {
+        ...mockProduct,
+        priceWithDiscount: undefined
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: undefinedDiscountProduct
+      });
+
+      expect(screen.queryByText(/-%/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("bestsellers block", () => {
+    test("should NOT render bestsellers block when percentageOfTotalOrders is undefined", () => {
+      const productWithoutPercentage = {
+        ...mockProduct,
+        percentageOfTotalOrders: undefined
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithoutPercentage
+      });
+
+      expect(screen.queryByTestId("best-sellers")).not.toBeInTheDocument();
+    });
+
+    test("should NOT render bestsellers block when percentageOfTotalOrders is 0", () => {
+      const productWithZeroPercentage = {
+        ...mockProduct,
+        percentageOfTotalOrders: 0
+      };
+
+      renderAndMock({
+        isProductInCart: false,
+        product: productWithZeroPercentage
+      });
+
+      expect(screen.queryByTestId("best-sellers")).not.toBeInTheDocument();
+    });
+
+    test("should render bestsellers when percentageOfTotalOrders > 0", () => {
+      const product = {
+        ...mockProduct,
+        percentageOfTotalOrders: 20
+      };
+
+      renderAndMock({ isProductInCart: false, product });
+
+      expect(screen.getByTestId("best-sellers")).toBeInTheDocument();
     });
   });
 });

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -62,7 +62,12 @@ const SaleProductCard = ({
       className="spa-product-card spa-sale-product-card"
       data-cy="product-card"
     >
-      <AppBox className="spa-sale-product-card__label">-{discount}%</AppBox>
+      <AppBox
+        className="spa-sale-product-card__label"
+        data-testid="discount-label"
+        >
+        -{discount}%
+      </AppBox>
       <AppLink
         className="spa-product-card__link-wrapper"
         to={routePaths.productDetails.path(id)}
@@ -96,6 +101,7 @@ const SaleProductCard = ({
               color: "blue"
             }}
             className="spa-product-card__best-sellers"
+            data-testid="best-sellers"
           >
             <AppTypography
               translationKey="bestsellers.title"

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
 
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+
 import AppBox from "@/components/app-box/AppBox";
 import AppIconButton from "@/components/app-icon-button/AppIconButton";
 import AppLink from "@/components/app-link/AppLink";
@@ -11,6 +14,7 @@ import cartIconWithPlus from "@/assets/icons/cart-with-plus.svg";
 import fallbackImage from "@/assets/images/default-product-image.png";
 import routePaths from "@/constants/routes";
 import useAddToCartOrOpenDrawer from "@/hooks/use-add-to-cart-or-open-drawer/useAddToCartOrOpenDrawer";
+import useToggleFavorite from "@/hooks/use-toggle-favorite/useToggleFavorite";
 import cn from "@/utils/cn/cn";
 import formatPrice from "@/utils/format-price/formatPrice";
 
@@ -37,9 +41,15 @@ const SaleProductCard = ({
   const roundedPercentage = Math.round(percentageOfTotalOrders || 0);
 
   const [imgSrc, setImgSrc] = useState(image);
+  const { toggle, isFavorite } = useToggleFavorite();
 
   const handleImageError = () => {
     setImgSrc(fallbackImage);
+  };
+
+  const handleFavoriteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    toggle(product.id);
   };
 
   const cartIconId = isProductInCart ? "cart-with-check" : "cart-with-plus";
@@ -115,18 +125,34 @@ const SaleProductCard = ({
             {formatPrice(priceWithDiscount ?? 0)}
           </AppTypography>
         </AppBox>
-        <AppIconButton
-          data-cy="add-to-cart-button"
-          onClick={addToCartOrOpenDrawer}
-          className={cn(
-            "spa-product-card__cart-button",
-            isProductInCart && "spa-product-card__cart-button--active"
-          )}
-        >
-          <svg>
-            <use data-testid="add-to-cart-icon" href={cartIconFullLink} />
-          </svg>
-        </AppIconButton>
+        <AppBox className="spa-product-card__footer-buttons">
+          <AppIconButton
+            data-cy="favorite-button"
+            onClick={handleFavoriteClick}
+            className={cn(
+              "spa-product-card__favorite-button",
+              isFavorite(product.id) && "spa-product-card__favorite-button--active"
+            )}
+          >
+            {isFavorite(product.id) ? (
+              <FavoriteIcon fontSize="small" />
+            ) : (
+              <FavoriteBorderIcon fontSize="small" />
+            )}
+          </AppIconButton>
+          <AppIconButton
+            data-cy="add-to-cart-button"
+            onClick={addToCartOrOpenDrawer}
+            className={cn(
+              "spa-product-card__cart-button",
+              isProductInCart && "spa-product-card__cart-button--active"
+            )}
+          >
+            <svg>
+              <use data-testid="add-to-cart-icon" href={cartIconFullLink} />
+            </svg>
+          </AppIconButton>
+        </AppBox>
       </AppBox>
     </AppBox>
   );

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.module.scss
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.module.scss
@@ -7,10 +7,6 @@
   display: flex;
   flex-direction: column;
 
-  &_grid {
-    margin-top: 16px;
-  }
-
   &_emptyMessage {
     display: flex;
     justify-content: center;
@@ -36,5 +32,18 @@
 
   &_sort {
     cursor: pointer;
+  }
+
+  &_productsGrid {
+    margin-top: spacing(4);
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    justify-content: flex-start;
+    width: 100%;
+    gap: spacing(16);
+
+    & > * {
+      width: 280px;
+    }
   }
 }

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
@@ -86,7 +86,7 @@ const MyWishlist = () => {
         />
       )}
       <ProductsContainer
-        className="spa-my-wishlist__grid"
+        className={styles.MyWishlist_productsGrid}
         products={productsList ?? []}
         isLoading={isLoading}
         loadingItemsCount={10}

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.scss
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.scss
@@ -63,6 +63,23 @@
     display: flex;
     column-gap: 15px;
     align-items: center;
+    justify-content: space-between;
+  }
+
+  &__buy-favorite-buttons {
+    display: flex;
+    column-gap: spacing(2);
+    justify-content: flex-end;
+  }
+
+  &__favorite-button {
+    color: $gray;
+    display: flex;
+    align-self: center;
+    
+    &--active {
+      color: $purple;
+    }
   }
 
   &__delivery-method-container {

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
@@ -1,9 +1,13 @@
 import { useIntl } from "react-intl";
 
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+
 import PageLoadingFallback from "@/containers/page-loading-fallback/PageLoadingFallback";
 
 import AppBadge from "@/components/app-badge/AppBadge";
 import AppBox from "@/components/app-box/AppBox";
+import AppIconButton from "@/components/app-icon-button/AppIconButton";
 import AppTypography from "@/components/app-typography/AppTypography";
 import PriceLabel from "@/components/price-label/PriceLabel";
 import ProductDescription from "@/components/product-description/ProductDescription";
@@ -12,12 +16,14 @@ import { deliveryMethods as deliveryMethodsData } from "@/constants/deliveryMeth
 import { useLocaleContext } from "@/context/i18n/I18nProvider";
 import useErrorPageRedirect from "@/hooks/use-error-page-redirect/useErrorPageRedirect";
 import useTrackVisits from "@/hooks/use-track-visits/useTrackVisits";
+import useToggleFavorite from "@/hooks/use-toggle-favorite/useToggleFavorite";
 import { ProductDetailsPageParams } from "@/pages/product-details/ProductDetails.types";
 import { productNotFoundRedirectConfig } from "@/pages/product-details/ProductsDetailsPage.constants";
 import BuyNowButton from "@/pages/product-details/components/buy-now-button/BuyNowButton";
 import { useGetUserProductByIdQuery } from "@/store/api/productsApi";
 import getCategoryFromTags from "@/utils/get-category-from-tags/getCategoryFromTags";
 import isErrorWithStatus from "@/utils/is-error-with-status/isErrorWithStatus";
+import cn from "@/utils/cn/cn";
 
 import "@/pages/product-details/components/product-details-container/ProductDetailsContainer.scss";
 
@@ -31,6 +37,7 @@ const ProductDetailsContainer = ({
   const { renderRedirectComponent } = useErrorPageRedirect();
   const { locale } = useLocaleContext();
   const { formatMessage } = useIntl();
+  const { toggle, isFavorite } = useToggleFavorite();
   const {
     data: product,
     isLoading,
@@ -128,6 +135,11 @@ const ProductDetailsContainer = ({
     />
   );
 
+  const handleFavoriteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    toggle(productId);
+  };
+
   return (
     <AppBox className="product-details">
       <AppBox className="product-details__image-wrapper">
@@ -159,7 +171,23 @@ const ProductDetailsContainer = ({
                 discountedPriceSize="h3"
                 discountedPriceWeight="bold"
               />
-              <BuyNowButton productWithId={productWithId} />
+              <AppBox className="product-details__buy-favorite-buttons">
+                <AppIconButton
+                  data-cy="favorite-button"
+                  onClick={handleFavoriteClick}
+                  className={cn(
+                    "product-details__favorite-button",
+                    isFavorite(productId) && "product-details__favorite-button--active"
+                  )}
+                >
+                {isFavorite(productId) ? (
+                  <FavoriteIcon fontSize="medium" />
+                ) : (
+                  <FavoriteBorderIcon fontSize="medium" />
+                )}
+                </AppIconButton>
+                <BuyNowButton productWithId={productWithId} />
+              </AppBox>
             </AppBox>
           </AppBox>
           <AppBox className="product-details__section">


### PR DESCRIPTION
* Added Favorite Icon to `ProductDetailsContainer`
* Added relevant styles

Favorite Icon when the user added to favorite:
<img width="1898" height="865" alt="image" src="https://github.com/user-attachments/assets/47f0be9a-c752-43fd-b051-b339273364f9" />

Favorite Icon when the user NOT added to favorite:
<img width="1898" height="875" alt="image" src="https://github.com/user-attachments/assets/7491793a-c6d8-4e64-84f8-4574f1afdf30" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to mark products as favorites on product cards, sale product cards, and the product details page. Favorite status is visually indicated with heart icons and an active state.
  * Bestsellers and discount labels are now conditionally displayed based on product data.

* **Style**
  * Improved layout and styling for favorite and buy buttons on the product details page.
  * Updated wishlist page grid layout for better product display.

* **Tests**
  * Expanded and reorganized tests to cover favorite functionality, bestsellers, and discount labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->