### PR TITLE
[GS3-73] Fixed  dark theme view

### DIFF
--- a/code/src/components/app-checkbox/AppCheckbox.scss
+++ b/code/src/components/app-checkbox/AppCheckbox.scss
@@ -26,11 +26,11 @@
 
   &__dark {
     & .MuiCheckbox-root svg {
-      fill: $black;
+      fill: var(--color-text);
     }
 
     & .spa-typography {
-      color: $black;
+      color: var(--color-text);
     }
   }
 }

--- a/code/src/components/bestseller-card/BestSellerCard.tsx
+++ b/code/src/components/bestseller-card/BestSellerCard.tsx
@@ -64,15 +64,7 @@ const BestSellerCard = ({ product }: ProductCardProps) => {
           </AppBox>
         </AppBox>
         {roundedPercentage > 0 && (
-          <AppBox
-            style={{
-              padding: "5px",
-              border: "3px solid blue",
-              borderRadius: "20px",
-              color: "blue"
-            }}
-            className="spa-product-card__best-sellers"
-          >
+          <AppBox className="spa-product-card__best-sellers">
             <AppTypography
               translationKey="bestsellers.title"
               translationProps={{

--- a/code/src/components/product-card/ProductCard.scss
+++ b/code/src/components/product-card/ProductCard.scss
@@ -9,6 +9,13 @@
   position: relative;
   overflow: hidden;
 
+  &__best-sellers {
+    padding: spacing(1);
+    border: 3px solid var(--color-primary);
+    border-radius: spacing(5);
+    color: var(--color-primary);
+  }
+
   &__link-wrapper {
     display: flex;
     flex-direction: column;
@@ -83,7 +90,7 @@
     color: $gray;
     display: flex;
     align-self: center;
-    
+
     &--active {
       color: $purple;
     }

--- a/code/src/components/product-sale-card/SaleProductCard.scss
+++ b/code/src/components/product-sale-card/SaleProductCard.scss
@@ -26,4 +26,11 @@
     display: flex;
     align-items: center;
   }
+
+    &__best-sellers {
+    padding: spacing(1);
+    border: 3px solid var(--color-primary);
+    border-radius: spacing(5);
+    color: var(--color-primary);
+  }
 }

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -94,12 +94,6 @@ const SaleProductCard = ({
         </AppBox>
         {roundedPercentage > 0 && (
           <AppBox
-            style={{
-              padding: "5px",
-              border: "3px solid blue",
-              borderRadius: "20px",
-              color: "blue"
-            }}
             className="spa-product-card__best-sellers"
             data-testid="best-sellers"
           >

--- a/code/src/pages/products/ProductsPage.scss
+++ b/code/src/pages/products/ProductsPage.scss
@@ -28,7 +28,7 @@
     cursor: pointer;
     background-color: var(--color-surface);
 
-    * {
+    div {
       color: inherit;
       background-color: inherit;
     }

--- a/code/src/pages/sales/components/sales-filter-drawer/SalesFilterDrawer.tsx
+++ b/code/src/pages/sales/components/sales-filter-drawer/SalesFilterDrawer.tsx
@@ -64,6 +64,7 @@ const SalesFilterDrawer = ({
         onChange={handleCheckboxListChange("tags", id)}
         data-testid={`sales-page-filter-${id.replace("category:", "")}-checkbox`}
         labelTranslationKey={translationKey}
+        variant="dark"
       />
     )
   );

--- a/code/src/styles/foundation/_theme.scss
+++ b/code/src/styles/foundation/_theme.scss
@@ -25,7 +25,7 @@
   --color-surface: #323232;
   --color-text: #ffffff;
   --color-muted: #b3b3b3;
-  --color-primary: #82b1ff;
+  --color-primary: #4983df;
   --color-secondary: #7e3eed;
   --color-danger: #d54545;
   --color-warning: #ffc107;

--- a/code/src/styles/foundation/_variables.scss
+++ b/code/src/styles/foundation/_variables.scss
@@ -8,7 +8,7 @@ $purple: #751fff;
 $purple-light: #d1b4ff;
 $red: #d72d2d;
 $orange: #eba008;
-$blue: #3b82f6;
+$blue: #0464ff;
 $green: #65aa34;
 $light-green: #c8fd4a;
 $white: #ffffff;


### PR DESCRIPTION
### Description 

- Fixed Sort dropdown colors issue. To successfully close issue need to be verified on production
- Fixed bestsellers hard-coded title color
- Added dark variant of checkbox, corresponding to the theme 

**Bestsellers :**
_Dark theme on_
<img width="582" height="448" alt="image" src="https://github.com/user-attachments/assets/24ed22c2-e7a9-4238-a52f-1835bd01f44a" />

_Ligth theme on_
<img width="576" height="459" alt="image" src="https://github.com/user-attachments/assets/d24c5cbe-be61-46fe-8639-3ac615394621" />

**Checkbox:**
_Dark theme on_
<img width="363" height="129" alt="image" src="https://github.com/user-attachments/assets/353b36d6-4805-48b7-9cd9-583f95d4bdd4" />

_Ligth theme on_
<img width="366" height="126" alt="image" src="https://github.com/user-attachments/assets/46cc3777-815b-417a-bbe8-3c8448629cb2" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated checkbox and bestseller badge colors for improved theming and consistency.
  * Replaced hardcoded colors with CSS variables for better theme support.
  * Adjusted bestseller badge styling for a more unified appearance across product cards.
  * Refined color palette in dark mode for enhanced visual clarity.
  * Scoped certain styles for more precise application within product and sales pages.

* **New Features**
  * Added a dark variant to category filter checkboxes in the sales filter drawer for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->