### PR TITLE
[GS-68] Implemented pagination for My Wishlist, updated endpoints

### DIFF
--- a/code/src/components/product-card/ProductCard.tsx
+++ b/code/src/components/product-card/ProductCard.tsx
@@ -21,10 +21,10 @@ import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import "@/components/product-card/ProductCard.scss";
 
-const ProductCard = ({ product, isViewHistory = false }: ProductCardProps) => {
+const ProductCard = ({ product, isViewHistory = false, wishlist = [] }: ProductCardProps) => {
   const { isProductInCart, addToCartOrOpenDrawer } =
     useAddToCartOrOpenDrawer(product);
-  const { toggle, isFavorite } = useToggleFavorite();
+  const { toggle, isFavorite } = useToggleFavorite(wishlist);
   const { id, name, image, price, description, percentageOfTotalOrders } =
     product;
 

--- a/code/src/components/product-card/ProductCard.types.ts
+++ b/code/src/components/product-card/ProductCard.types.ts
@@ -3,4 +3,5 @@ import { Product } from "@/types/product.types";
 export type ProductCardProps = {
   product: Product;
   isViewHistory?: boolean;
+  wishlist?: Product[];
 };

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -22,7 +22,8 @@ import "@/components/product-sale-card/SaleProductCard.scss";
 
 const SaleProductCard = ({
   product,
-  isViewHistory = false
+  isViewHistory = false,
+  wishlist = []
 }: ProductCardProps) => {
   const { isProductInCart, addToCartOrOpenDrawer } =
     useAddToCartOrOpenDrawer(product);
@@ -41,7 +42,7 @@ const SaleProductCard = ({
   const roundedPercentage = Math.round(percentageOfTotalOrders || 0);
 
   const [imgSrc, setImgSrc] = useState(image);
-  const { toggle, isFavorite } = useToggleFavorite();
+  const { toggle, isFavorite } = useToggleFavorite(wishlist);
 
   const handleImageError = () => {
     setImgSrc(fallbackImage);

--- a/code/src/constants/requests.ts
+++ b/code/src/constants/requests.ts
@@ -98,9 +98,11 @@ export const URLS = {
       `/v1/my-view-history/${productId}`,
     deleteAll: "/v1/my-view-history"
   },
-    wishlist: {
-    get: "/v1/wishlist",
-    put: (productId: string) => `/v1/wishlist/${productId}`,
-    delete: (productId: string) => `/v1/wishlist/${productId}`,
+  wishlist: {
+    get: "/v1/my-wishlist",
+    put: ({ productId }: { productId: string }) =>
+      `/v1/my-wishlist/${productId}`,
+    delete: ({ productId }: { productId: string }) =>
+      `/v1/my-wishlist/${productId}`,
   }
 } as const;

--- a/code/src/containers/products-container/ProductsContainer.tsx
+++ b/code/src/containers/products-container/ProductsContainer.tsx
@@ -23,7 +23,8 @@ const ProductsContainer = ({
   loadingItemsCount = 5,
   maxColumns = 5,
   errorMessage = "errors.somethingWentWrong",
-  isViewHistory = false
+  isViewHistory = false,
+  wishlist = [],
 }: ProductsContainerProps) => {
   const { isLoading: isCartLoading } = useGetCart();
   const isAuthLoading = useIsAuthLoadingSelector();
@@ -50,12 +51,14 @@ const ProductsContainer = ({
           key={product.id}
           product={product}
           isViewHistory={isViewHistory}
+          wishlist={wishlist}
         />
       ) : (
         <ProductCard
           key={product.id}
           product={product}
           isViewHistory={isViewHistory}
+          wishlist={wishlist}
         />
       );
 

--- a/code/src/containers/products-container/ProductsContainer.types.ts
+++ b/code/src/containers/products-container/ProductsContainer.types.ts
@@ -9,6 +9,7 @@ export type ProductsContainerProps = {
   errorMessage?: string;
   maxColumns?: number;
   isViewHistory?: boolean;
+  wishlist?: Product[];
 };
 
 export type HandleCartIconClickParam = Product & { isInCart: boolean };

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.test.tsx
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.test.tsx
@@ -19,7 +19,11 @@ jest.mock("@/context/i18n/I18nProvider", () => ({
   useLocaleContext: jest.fn(() => ({ locale: "en" })),
 }));
 
-const mockData = { content: mockProducts, totalElements: mockProducts.length };
+const mockData = {
+  content: mockProducts,
+  totalElements: mockProducts.length,
+  totalPages: 3
+};
 
 jest.mock("@/containers/products-container/ProductsContainer", () => ({
   __esModule: true,
@@ -82,7 +86,7 @@ describe("MyWishlist", () => {
   });
 
   test("should show empty message, title, 0 products and sort options when wishlist is empty", () => {
-    renderAndMock({ mockResponse: { data: { content: [], totalElements: 0 } } });
+    renderAndMock({ mockResponse: { data: { content: [], totalElements: 0, totalPages: 3 } } });
 
     expect(screen.getByText(/myWishlist.emptyMessage/i)).toBeInTheDocument();
     expect(screen.getByText(/myWishlist.title/i)).toBeInTheDocument();
@@ -119,9 +123,22 @@ describe("MyWishlist", () => {
 
     renderAndMock();
 
-    expect(mockUseGetUserWishlistQuery).toHaveBeenCalledWith({
-      sort: "bestsellers,desc",
-      lang: "en",
-    });
+    expect(mockUseGetUserWishlistQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: "bestsellers,desc",
+        lang: "en",
+      })
+    );
+  });
+
+  test("should render PaginationBlock with correct props", () => {
+    renderAndMock();
+
+    expect(screen.getByText(/myWishlist.title/i)).toBeInTheDocument();
+    expect(mockUseGetUserWishlistQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page: 0,
+      })
+    );
   });
 });

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
@@ -23,7 +23,7 @@ const MyWishlist = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { page } = usePagination();
   const screenSize = useScreenSize();
-  const size = setProductsPerPageSize(screenSize.width);
+  const size = Math.min(setProductsPerPageSize(screenSize.width), 6);
 
   const sortOption = searchParams.get("sort");
 

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
@@ -11,12 +11,18 @@ import AppTypography from "@/components/app-typography/AppTypography";
 import { useGetUserWishlistQuery } from "@/store/api/wishlistApi";
 import { useLocaleContext } from "@/context/i18n/I18nProvider";
 import { sortOptions } from "@/pages/products/ProductsPage.constants";
+import usePagination from "@/hooks/use-pagination/usePagination";
+import setProductsPerPageSize from "@/utils/set-product-size/setProductsPerPageSize";
+import useScreenSize from "@/utils/check-screen-size/useScreenSize";
 
 import * as styles from "@/containers/user-account/my-wishlist/MyWishlist.module.scss";
 
 const MyWishlist = () => {
   const { locale } = useLocaleContext();
   const [searchParams, setSearchParams] = useSearchParams();
+  const { page } = usePagination();
+  const screenSize = useScreenSize();
+  const size = setProductsPerPageSize(screenSize.width);
 
   const sortOption = searchParams.get("sort");
 
@@ -24,6 +30,8 @@ const MyWishlist = () => {
     data: wishlist,
     isLoading,
   } = useGetUserWishlistQuery({
+    page: page - 1,
+    size,
     sort: sortOption ?? undefined,
     lang: locale
   });
@@ -90,6 +98,7 @@ const MyWishlist = () => {
         products={productsList ?? []}
         isLoading={isLoading}
         loadingItemsCount={10}
+        wishlist={productsList ?? []}
       />
     </AppContainer>
   );

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
@@ -2,6 +2,7 @@ import { useSearchParams } from "react-router-dom";
 
 import ProductsContainer from "@/containers/products-container/ProductsContainer";
 import PageLoadingFallback from "@/containers/page-loading-fallback/PageLoadingFallback";
+import PaginationBlock from "@/containers/pagination-block/PaginationBlock";
 
 import AppBox from "@/components/app-box/AppBox";
 import AppContainer from "@/components/app-container/AppContainer";
@@ -99,6 +100,10 @@ const MyWishlist = () => {
         isLoading={isLoading}
         loadingItemsCount={10}
         wishlist={productsList ?? []}
+      />
+      <PaginationBlock
+        page={page}
+        totalPages={wishlist?.totalPages}
       />
     </AppContainer>
   );

--- a/code/src/containers/user-account/view-history/UserViewHistory.test.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.test.tsx
@@ -7,6 +7,7 @@ import {
   useDeleteAllViewProductsMutation,
   useGetViewHistoryApiQuery
 } from "@/store/api/viewHistoryApi";
+import { useGetUserWishlistQuery } from "@/store/api/wishlistApi";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
 
 import UserViewHistoryPage from "./UserViewHistory";
@@ -24,6 +25,9 @@ const mockProducts = [
 
 const mockData = { content: mockProducts, totalPages: 2, totalElements: 8 };
 const deleteAllViewProductsMock = jest.fn();
+
+jest.mock("@/store/api/wishlistApi");
+const mockUseGetUserWishlistQuery = useGetUserWishlistQuery as jest.Mock;
 
 const mockSetSearchParams = jest.fn();
 const mockSearchParams = new URLSearchParams();
@@ -77,12 +81,14 @@ const renderAndMock = ({
   mockResponse = {},
   isLoading = false,
   isError = false,
-  error
+  error,
+  wishlistResponse = { content: [] }
 }: {
   mockResponse?: Partial<ReturnType<typeof useGetViewHistoryApiQuery>>;
   isLoading?: boolean;
   isError?: boolean;
   error?: { status: number };
+  wishlistResponse?: { content: typeof mockProducts };
 } = {}) => {
   (useDeleteAllViewProductsMutation as jest.Mock).mockReturnValue([
     deleteAllViewProductsMock
@@ -93,6 +99,13 @@ const renderAndMock = ({
     isError,
     data: mockResponse?.data ?? mockData,
     error: error ?? null
+  });
+
+  mockUseGetUserWishlistQuery.mockReturnValue({
+    data: wishlistResponse,
+    isLoading: false,
+    isError: false,
+    error: null
   });
 
   return renderWithProviders(<UserViewHistoryPage />);
@@ -112,7 +125,9 @@ describe("UserViewHistory", () => {
   });
 
   it("should show no products message when no products", () => {
-    renderAndMock({ mockResponse: { data: { content: [] } } });
+    renderAndMock({
+      mockResponse: { data: { content: [], totalElements: 0, totalPages: 0 } }
+    });
     const noProducts = screen.getByText("userViewHistory.noProducts");
 
     expect(noProducts).toBeInTheDocument();
@@ -150,17 +165,6 @@ describe("UserViewHistory", () => {
 
     const updatedParams = mockSetSearchParams.mock.calls[0][0].toString();
     expect(updatedParams).toContain("sort=viewedAt%2CASC");
-  });
-
-  it("should handle page not found error", () => {
-    renderAndMock({
-      error: { status: 404 },
-      isError: true
-    });
-
-    const errorMessage = screen.getByText("product.productNotFound");
-
-    expect(errorMessage).toBeInTheDocument();
   });
 
   it("should handle page not found error", () => {

--- a/code/src/containers/user-account/view-history/UserViewHistory.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.tsx
@@ -22,6 +22,7 @@ import {
   useDeleteAllViewProductsMutation,
   useGetViewHistoryApiQuery
 } from "@/store/api/viewHistoryApi";
+import { useGetUserWishlistQuery } from "@/store/api/wishlistApi";
 import useScreenSize from "@/utils/check-screen-size/useScreenSize";
 import isErrorWithStatus from "@/utils/is-error-with-status/isErrorWithStatus";
 import repeatComponent from "@/utils/repeat-component/repeatComponent";
@@ -50,6 +51,9 @@ const UserViewHistory = () => {
     sort: sortOption ?? undefined,
     lang: locale
   });
+
+  const { data: wishlistData } = useGetUserWishlistQuery();
+  const wishlist = wishlistData?.content ?? [];
 
   const pagesCount = viewHistoryResponse?.totalPages ?? 1;
 
@@ -102,6 +106,7 @@ const UserViewHistory = () => {
       <ProductsContainer
         products={viewHistoryResponse!.content}
         isViewHistory
+        wishlist={wishlist}
       />
     );
   };

--- a/code/src/hooks/use-toggle-favorite/useToggleFavorite.test.ts
+++ b/code/src/hooks/use-toggle-favorite/useToggleFavorite.test.ts
@@ -49,8 +49,8 @@ describe("useToggleFavorite", () => {
   test("toggle calls removeFromWishlist if product is favorite", async () => {
     const { result } = renderHook(() => useToggleFavorite(mockWishlist));
 
-    await act(async () => {
-      await result.current.toggle("1");
+    act(() => {
+      result.current.toggle("1");
     });
 
     expect(mockRemoveFromWishlist).toHaveBeenCalledWith("1");
@@ -60,8 +60,8 @@ describe("useToggleFavorite", () => {
   test("toggle calls addToWishlist if product is not favorite", async () => {
     const { result } = renderHook(() => useToggleFavorite(mockWishlist));
 
-    await act(async () => {
-      await result.current.toggle("3");
+    act(() => {
+      result.current.toggle("3");
     });
 
     expect(mockAddToWishlist).toHaveBeenCalledWith("3");
@@ -73,8 +73,8 @@ describe("useToggleFavorite", () => {
 
     expect(result.current.isFavorite("abc")).toBe(false);
 
-    await act(async () => {
-      await result.current.toggle("abc");
+    act(() => {
+      result.current.toggle("abc");
     });
 
     expect(mockAddToWishlist).toHaveBeenCalledWith("abc");

--- a/code/src/hooks/use-toggle-favorite/useToggleFavorite.test.ts
+++ b/code/src/hooks/use-toggle-favorite/useToggleFavorite.test.ts
@@ -1,148 +1,82 @@
 import { renderHook, act } from "@testing-library/react";
-import { useSearchParams } from "react-router-dom";
 
 import useToggleFavorite from "@/hooks/use-toggle-favorite/useToggleFavorite";
 import {
   useAddToWishlistMutation,
-  useRemoveFromWishlistMutation,
-  useGetUserWishlistQuery,
+  useRemoveFromWishlistMutation
 } from "@/store/api/wishlistApi";
+import { Product } from "@/types/product.types";
 
 jest.mock("@/store/api/wishlistApi", () => ({
-  useGetUserWishlistQuery: jest.fn(),
   useAddToWishlistMutation: jest.fn(),
-  useRemoveFromWishlistMutation: jest.fn(),
+  useRemoveFromWishlistMutation: jest.fn()
 }));
 
-jest.mock("@/context/i18n/I18nProvider", () => ({
-  ...jest.requireActual("@/context/i18n/I18nProvider"),
-  useLocaleContext: () => ({ locale: "en" }),
-}));
-
-jest.mock("react-router-dom", () => {
-  const actual = jest.requireActual("react-router-dom");
-  return {
-    ...actual,
-    useSearchParams: jest.fn(),
-  };
-});
-
-const mockUseSearchParams = useSearchParams as jest.Mock;
-const mockUseGetUserWishlistQuery = useGetUserWishlistQuery as jest.Mock;
 const mockAddToWishlist = jest.fn();
 const mockRemoveFromWishlist = jest.fn();
 
+const mockProduct: Product = {
+  id: "123",
+  name: "Mobile Phone Samsung Galaxy A55 5G 8/256GB Lilac",
+  description:
+    'Screen: 6.6" Super AMOLED, 2340x1080 / Samsung Exynos 1480 (4 x 2.75 GHz + 4 x 2.0 GHz) / Main Triple Camera: 50 MP + 12 MP + 5 MP, Front Camera: 32 MP / RAM 8 GB / 256 GB internal storage + microSD (up to 1 TB) / 3G / LTE / 5G / GPS / A-GPS / GLONASS / BDS / Dual SIM support (Nano-SIM) / Android 14 / 5000 mAh',
+  status: "AVAILABLE",
+  tags: ["category:mobile"],
+  image:
+    "https://j65jb0fdkxuua0go.public.blob.vercel-storage.com/phone_2-tTDYhyoyqsEkwPzySFdXflYCe7TkUb.jpg",
+  price: 500
+};
+
 describe("useToggleFavorite", () => {
   beforeEach(() => {
-    const params = new URLSearchParams();
-    params.set("sort", "bestsellers,desc");
-
-    mockUseSearchParams.mockReturnValue([params]);
-
     (useAddToWishlistMutation as jest.Mock).mockReturnValue([mockAddToWishlist]);
-    (useRemoveFromWishlistMutation as jest.Mock).mockReturnValue([
-      mockRemoveFromWishlist,
-    ]);
-
+    (useRemoveFromWishlistMutation as jest.Mock).mockReturnValue([mockRemoveFromWishlist]);
     jest.clearAllMocks();
   });
 
   const mockWishlist = [
-    { id: "1", name: "Phone 1" },
-    { id: "2", name: "Phone 2" },
+    { ...mockProduct, id: "1", name: "Product 1" },
+    { ...mockProduct, id: "2", name: "Product 2" }
   ];
 
-  test("should return wishlist and flags correctly", () => {
-    mockUseGetUserWishlistQuery.mockReturnValue({
-      data: { content: mockWishlist },
-      isLoading: false,
-      isError: false,
-    });
-
-    const { result } = renderHook(() => useToggleFavorite());
-
-    expect(result.current.wishlist).toEqual(mockWishlist);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.isError).toBe(false);
-  });
-
   test("isFavorite returns true for existing product", () => {
-    mockUseGetUserWishlistQuery.mockReturnValue({
-      data: { content: mockWishlist },
-      isLoading: false,
-      isError: false,
-    });
-
-    const { result } = renderHook(() => useToggleFavorite());
+    const { result } = renderHook(() => useToggleFavorite(mockWishlist));
 
     expect(result.current.isFavorite("1")).toBe(true);
     expect(result.current.isFavorite("999")).toBe(false);
   });
 
-  test("toggle calls removeFromWishlist if product is favorite", () => {
-    mockUseGetUserWishlistQuery.mockReturnValue({
-      data: { content: mockWishlist },
-      isLoading: false,
-      isError: false,
+  test("toggle calls removeFromWishlist if product is favorite", async () => {
+    const { result } = renderHook(() => useToggleFavorite(mockWishlist));
+
+    await act(async () => {
+      await result.current.toggle("1");
     });
 
-    const { result } = renderHook(() => useToggleFavorite());
-
-    act(() => {
-      result.current.toggle("2");
-    });
-
-    expect(mockRemoveFromWishlist).toHaveBeenCalledWith("2");
+    expect(mockRemoveFromWishlist).toHaveBeenCalledWith("1");
     expect(mockAddToWishlist).not.toHaveBeenCalled();
   });
 
-  test("toggle calls addToWishlist if product is not favorite", () => {
-    mockUseGetUserWishlistQuery.mockReturnValue({
-      data: { content: mockWishlist },
-      isLoading: false,
-      isError: false,
+  test("toggle calls addToWishlist if product is not favorite", async () => {
+    const { result } = renderHook(() => useToggleFavorite(mockWishlist));
+
+    await act(async () => {
+      await result.current.toggle("3");
     });
 
-    const { result } = renderHook(() => useToggleFavorite());
-
-    act(() => {
-      result.current.toggle("5");
-    });
-
-    expect(mockAddToWishlist).toHaveBeenCalledWith("5");
+    expect(mockAddToWishlist).toHaveBeenCalledWith("3");
     expect(mockRemoveFromWishlist).not.toHaveBeenCalled();
   });
 
-  test("works correctly with empty wishlist", () => {
-    mockUseGetUserWishlistQuery.mockReturnValue({
-      data: { content: [] },
-      isLoading: false,
-      isError: false,
-    });
-
-    const { result } = renderHook(() => useToggleFavorite());
+  test("handles empty wishlist correctly", async () => {
+    const { result } = renderHook(() => useToggleFavorite([]));
 
     expect(result.current.isFavorite("abc")).toBe(false);
 
-    act(() => {
-      result.current.toggle("abc");
+    await act(async () => {
+      await result.current.toggle("abc");
     });
 
     expect(mockAddToWishlist).toHaveBeenCalledWith("abc");
-  });
-
-  test("calls useGetUserWishlistQuery with correct params", () => {
-    mockUseGetUserWishlistQuery.mockReturnValue({
-      data: { content: [] },
-      isLoading: false,
-      isError: false,
-    });
-
-    renderHook(() => useToggleFavorite());
-
-    expect(mockUseGetUserWishlistQuery).toHaveBeenCalledWith({
-      lang: "en",
-      sort: "bestsellers,desc",
-    });
   });
 });

--- a/code/src/hooks/use-toggle-favorite/useToggleFavorite.ts
+++ b/code/src/hooks/use-toggle-favorite/useToggleFavorite.ts
@@ -1,45 +1,26 @@
-import { useSearchParams } from "react-router-dom";
-
-import { useLocaleContext } from "@/context/i18n/I18nProvider";
 import {
-  useGetUserWishlistQuery,
   useAddToWishlistMutation,
   useRemoveFromWishlistMutation
 } from "@/store/api/wishlistApi";
+import { Product } from "@/types/product.types";
 
 
-const useToggleFavorite = () => {
-  const { locale } = useLocaleContext();
-  const [searchParams] = useSearchParams();
-
-  const sort = searchParams.get("sort") ?? undefined;
-
-  const {
-    data: wishlistData,
-    isLoading,
-    isError,
-  } = useGetUserWishlistQuery({
-    lang: locale,
-    sort
-  });
-
-  const wishlist = wishlistData?.content ?? [];
-
+const useToggleFavorite = (wishlist: Product[]) => {
   const [addToWishlist] = useAddToWishlistMutation();
   const [removeFromWishlist] = useRemoveFromWishlistMutation();
 
   const isFavorite = (productId: string): boolean =>
     wishlist.some((item) => item.id === productId);
 
-  const toggle = (productId: string) => {
+  const toggle = async (productId: string) => {
     if (isFavorite(productId)) {
-      removeFromWishlist(productId);
+      await removeFromWishlist(productId);
     } else {
-      addToWishlist(productId);
+      await addToWishlist(productId);
     }
   };
 
-  return { toggle, isFavorite, wishlist, isLoading, isError };
+  return { toggle, isFavorite, wishlist };
 };
 
 export default useToggleFavorite;

--- a/code/src/pages/products/ProductsPage.test.tsx
+++ b/code/src/pages/products/ProductsPage.test.tsx
@@ -4,6 +4,7 @@ import { ProductsContainerProps } from "@/containers/products-container/Products
 
 import ProductsPage from "@/pages/products/ProductsPage";
 import { useGetUserProductsQuery } from "@/store/api/productsApi";
+import { useGetUserWishlistQuery } from "@/store/api/wishlistApi";
 import { PaginationParams, RTKQueryReturnState } from "@/types/common";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
 import setProductsPerPageSize from "@/utils/set-product-size/setProductsPerPageSize";
@@ -18,12 +19,17 @@ const mockProducts = [
   { id: 7, name: "Product 7", price: 300 },
   { id: 8, name: "Product 8", price: 400 }
 ];
+const mockWishlist = [{ id: 1 }];
 
 const mockData = { content: mockProducts, totalPages: 2, totalElements: 8 };
 
 jest.mock("@/containers/products-container/ProductsContainer", () => ({
   __esModule: true,
-  default: ({ isLoading, isError, products }: ProductsContainerProps) => (
+  default: ({
+    isLoading,
+    isError,
+    products
+  }: ProductsContainerProps) => (
     <div data-testid="products-container">
       {isLoading && <div>Loading...</div>}
       {isError && <div>Error!</div>}
@@ -39,6 +45,10 @@ jest.mock("@/containers/products-container/ProductsContainer", () => ({
 
 jest.mock("@/store/api/productsApi", () => ({
   useGetUserProductsQuery: jest.fn()
+}));
+
+jest.mock("@/store/api/wishlistApi", () => ({
+  useGetUserWishlistQuery: jest.fn()
 }));
 
 jest.mock("@/context/i18n/I18nProvider", () => ({
@@ -75,11 +85,13 @@ jest
 const renderAndMock = (
   {
     entries = "",
-    mockResponse = {}
+    mockResponse = {},
+    wishlist = []
   }: {
     entries?: string;
     mockResponse?: Partial<RTKQueryReturnState<Partial<typeof mockData>>>;
-  } = { entries: "", mockResponse: {} }
+    wishlist?: typeof mockWishlist;
+  } = {}
 ) => {
   (useGetUserProductsQuery as jest.Mock).mockReturnValue({
     isLoading: false,
@@ -91,6 +103,12 @@ const renderAndMock = (
       "data" in mockResponse && !mockResponse.data
         ? mockResponse.data
         : { ...mockData, ...mockResponse.data }
+  });
+
+  (useGetUserWishlistQuery as jest.Mock).mockReturnValue({
+    isLoading: false,
+    isError: false,
+    data: { content: wishlist }
   });
 
   return renderWithProviders(<ProductsPage />, { initialEntries: [entries] });

--- a/code/src/pages/products/ProductsPage.tsx
+++ b/code/src/pages/products/ProductsPage.tsx
@@ -15,6 +15,7 @@ import usePagination from "@/hooks/use-pagination/usePagination";
 import useTrackVisits from "@/hooks/use-track-visits/useTrackVisits";
 import { sortOptions } from "@/pages/products/ProductsPage.constants";
 import { useGetUserProductsQuery } from "@/store/api/productsApi";
+import { useGetUserWishlistQuery } from "@/store/api/wishlistApi";
 import useScreenSize from "@/utils/check-screen-size/useScreenSize";
 import setProductsPerPageSize from "@/utils/set-product-size/setProductsPerPageSize";
 
@@ -46,6 +47,9 @@ const ProductsPage = () => {
     size,
     lang: locale
   });
+
+  const { data: wishlistData } = useGetUserWishlistQuery();
+  const wishlist = wishlistData?.content ?? [];
 
   const productsList = productsResponse?.content;
 
@@ -116,6 +120,7 @@ const ProductsPage = () => {
           loadingItemsCount={10}
           isLoading={isLoading}
           isError={isError}
+          wishlist={wishlist}
         />
         <PaginationBlock
           page={page}

--- a/code/src/pages/sales/SalesPage.test.tsx
+++ b/code/src/pages/sales/SalesPage.test.tsx
@@ -4,6 +4,7 @@ import usePagination from "@/hooks/use-pagination/usePagination";
 import SalesPage from "@/pages/sales/SalesPage";
 import useSalesFilter from "@/pages/sales/hooks/useSalesFilter";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
+import { useGetUserWishlistQuery } from "@/store/api/wishlistApi";
 
 jest.mock("@/pages/sales/SalesPage.constants", () => ({
   sortSaleOptions: [
@@ -26,6 +27,9 @@ jest.mock(
     )
   })
 );
+
+jest.mock("@/store/api/wishlistApi");
+const mockUseGetUserWishlistQuery = useGetUserWishlistQuery as jest.Mock;
 
 jest.mock("@/containers/products-container/ProductsContainer", () => ({
   __esModule: true,
@@ -76,7 +80,7 @@ const mockSales = [
   { id: 3, name: "Sale Product 3", price: 150 }
 ];
 
-const renderAndMock = (mockResponse = {}) => {
+const renderAndMock = (mockResponse = {}, wishlistResponse = []) => {
   (useSalesFilter as jest.Mock).mockReturnValue({
     sales: mockSales,
     totalPages: 3,
@@ -87,7 +91,15 @@ const renderAndMock = (mockResponse = {}) => {
     totalElements: mockSales.length,
     isLoading: false,
     isError: false,
+    wishlistResponse: typeof mockSales,
     ...mockResponse
+  });
+
+  mockUseGetUserWishlistQuery.mockReturnValue({
+    data: wishlistResponse,
+    isLoading: false,
+    isError: false,
+    error: null
   });
   return renderWithProviders(<SalesPage />);
 };

--- a/code/src/pages/sales/SalesPage.tsx
+++ b/code/src/pages/sales/SalesPage.tsx
@@ -15,6 +15,7 @@ import AppDropdown from "@/components/app-dropdown/AppDropdown";
 import AppTypography from "@/components/app-typography/AppTypography";
 
 import usePagination from "@/hooks/use-pagination/usePagination";
+import { useGetUserWishlistQuery } from "@/store/api/wishlistApi";
 import { sortSaleOptions } from "@/pages/sales/SalesPage.constants";
 import SalesFilterDrawer from "@/pages/sales/components/sales-filter-drawer/SalesFilterDrawer";
 import useSalesFilter from "@/pages/sales/hooks/useSalesFilter";
@@ -37,6 +38,9 @@ const SalesPage = () => {
     isLoading,
     isError
   } = useSalesFilter({ sort: sortOption ?? undefined });
+
+  const { data: wishlistData } = useGetUserWishlistQuery();
+  const wishlist = wishlistData?.content ?? [];
 
   const [isFilterDrawerOpened, setIsFilterDrawerOpened] = useState(false);
 
@@ -120,6 +124,7 @@ const SalesPage = () => {
             isLoading={isLoading}
             isError={isError}
             maxColumns={3}
+            wishlist={wishlist}
           />
           {totalPages > 1 && (
             <PaginationBlock

--- a/code/src/store/api/wishlistApi.ts
+++ b/code/src/store/api/wishlistApi.ts
@@ -22,15 +22,15 @@ export const wishlistApi = appApi.injectEndpoints({
       providesTags: [rtkQueryTags.WISHLIST]
     }),
     addToWishlist: build.mutation<void, string>({
-      query: (productId) => ({
-        url: URLS.wishlist.put(productId),
+      query: (productId: string) => ({
+        url: URLS.wishlist.put({ productId }),
         method: httpMethods.put
       }),
       invalidatesTags: [rtkQueryTags.WISHLIST]
     }),
     removeFromWishlist: build.mutation<void, string>({
-      query: (productId) => ({
-        url: URLS.wishlist.delete(productId),
+      query: (productId: string) => ({
+        url: URLS.wishlist.delete({ productId }),
         method: httpMethods.delete
       }),
       invalidatesTags: [rtkQueryTags.WISHLIST]


### PR DESCRIPTION
* Updated endpoints
* Updated `useToggleFavorite` hook and its usage on the pages that contains `ProductsContainer`
* Added pagination
* Updated tests

**Pagination:**
<img width="751" height="799" alt="image" src="https://github.com/user-attachments/assets/fcb79525-5484-4f22-9e4c-12508d69ddf6" />

**Endpoint GET, PUT, DELETE:**
<img width="1882" height="778" alt="image" src="https://github.com/user-attachments/assets/ff039866-ac8b-4778-a73b-0d74ef41940a" />
<img width="1913" height="865" alt="image" src="https://github.com/user-attachments/assets/65d7dfd5-f19e-482b-beec-070c43024ef3" />
<img width="1870" height="780" alt="image" src="https://github.com/user-attachments/assets/1991a76a-8793-4c90-a2c8-d4fa5242e0fe" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing and displaying a user's wishlist across product listings, sales, and view history pages.
  * Integrated pagination and responsive page sizing for the wishlist view.
  * Wishlist data is now visible and synchronized in product cards and sales cards.

* **Bug Fixes**
  * Improved wishlist management to ensure accurate favorite toggling and display.

* **Tests**
  * Enhanced and added tests to cover wishlist integration, pagination, and favorite toggling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->