### PR TITLE
[GS3-81] Added role condition

### DIFF
--- a/code/src/pages/product-details/ProductDetailsPage.test.tsx
+++ b/code/src/pages/product-details/ProductDetailsPage.test.tsx
@@ -10,6 +10,7 @@ import {
   useUserRoleSelector
 } from "@/store/slices/userSlice";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
+type RoleType = (typeof ROLES)[keyof typeof ROLES];
 
 const mockRenderRedirectComponent = jest.fn();
 
@@ -41,18 +42,18 @@ jest.mock("@/store/slices/userSlice", () => ({
   useUserRoleSelector: jest.fn()
 }));
 const addViewedProductMock = jest.fn();
-const renderAndMock = (productId?: string, isAuthenticated?: boolean) => {
+const renderAndMock = (productId?: string, isAuthenticated?: boolean, currentRole?:RoleType) => {
   (useParams as jest.Mock).mockReturnValue({ productId });
   (useUpdateViewedProductsMutation as jest.Mock).mockReturnValue([
     addViewedProductMock
   ]);
   (useIsAuthSelector as jest.Mock).mockReturnValue(isAuthenticated);
-  (useUserRoleSelector as jest.Mock).mockReturnValue(ROLES.USER);
+  (useUserRoleSelector as jest.Mock).mockReturnValue(currentRole);
 
   renderWithProviders(<ProductDetailsPage />);
 };
 
-describe("ProductsDetailsPage", () => {
+describe("ProductDetailsPage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -73,7 +74,7 @@ describe("ProductsDetailsPage", () => {
   });
 
   test("calls addViewProduct with productId when productId is defined", () => {
-    renderAndMock("2", true);
+    renderAndMock("2", true, ROLES.USER);
     expect(addViewedProductMock).toHaveBeenCalledWith("2");
   });
 
@@ -81,4 +82,22 @@ describe("ProductsDetailsPage", () => {
     renderAndMock("3", false);
     expect(addViewedProductMock).not.toHaveBeenCalled();
   });
+
+  test("does not addViewProduct when user role is Admin", () => {
+  (useUserRoleSelector as jest.Mock).mockReturnValue(ROLES.ADMIN);
+  renderAndMock("3", true);
+  expect(addViewedProductMock).not.toHaveBeenCalled();
+});
+
+test("does not addViewProduct when user role is Manager", () => {
+  (useUserRoleSelector as jest.Mock).mockReturnValue(ROLES.SHOP_MANAGER);
+  renderAndMock("3", true);
+  expect(addViewedProductMock).not.toHaveBeenCalled();
+});
+
+test("does not addViewProduct when user role is null", () => {
+  (useUserRoleSelector as jest.Mock).mockReturnValue(null);
+  renderAndMock("3", true);
+  expect(addViewedProductMock).not.toHaveBeenCalled();
+});
 });

--- a/code/src/pages/product-details/ProductDetailsPage.test.tsx
+++ b/code/src/pages/product-details/ProductDetailsPage.test.tsx
@@ -10,6 +10,7 @@ import {
   useUserRoleSelector
 } from "@/store/slices/userSlice";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
+
 type RoleType = (typeof ROLES)[keyof typeof ROLES];
 
 const mockRenderRedirectComponent = jest.fn();
@@ -42,7 +43,11 @@ jest.mock("@/store/slices/userSlice", () => ({
   useUserRoleSelector: jest.fn()
 }));
 const addViewedProductMock = jest.fn();
-const renderAndMock = (productId?: string, isAuthenticated?: boolean, currentRole?:RoleType) => {
+const renderAndMock = (
+  productId?: string,
+  isAuthenticated?: boolean,
+  currentRole?: RoleType | null
+) => {
   (useParams as jest.Mock).mockReturnValue({ productId });
   (useUpdateViewedProductsMutation as jest.Mock).mockReturnValue([
     addViewedProductMock
@@ -84,20 +89,17 @@ describe("ProductDetailsPage", () => {
   });
 
   test("does not addViewProduct when user role is Admin", () => {
-  (useUserRoleSelector as jest.Mock).mockReturnValue(ROLES.ADMIN);
-  renderAndMock("3", true);
-  expect(addViewedProductMock).not.toHaveBeenCalled();
-});
+    renderAndMock("3", true, ROLES.ADMIN);
+    expect(addViewedProductMock).not.toHaveBeenCalled();
+  });
 
-test("does not addViewProduct when user role is Manager", () => {
-  (useUserRoleSelector as jest.Mock).mockReturnValue(ROLES.SHOP_MANAGER);
-  renderAndMock("3", true);
-  expect(addViewedProductMock).not.toHaveBeenCalled();
-});
+  test("does not addViewProduct when user role is Manager", () => {
+    renderAndMock("3", true, ROLES.SHOP_MANAGER);
+    expect(addViewedProductMock).not.toHaveBeenCalled();
+  });
 
-test("does not addViewProduct when user role is null", () => {
-  (useUserRoleSelector as jest.Mock).mockReturnValue(null);
-  renderAndMock("3", true);
-  expect(addViewedProductMock).not.toHaveBeenCalled();
-});
+  test("does not addViewProduct when user role is null", () => {
+    renderAndMock("3", true, null);
+    expect(addViewedProductMock).not.toHaveBeenCalled();
+  });
 });

--- a/code/src/pages/product-details/ProductDetailsPage.tsx
+++ b/code/src/pages/product-details/ProductDetailsPage.tsx
@@ -25,15 +25,15 @@ const ProductDetailsPage = () => {
   const isAuthenticated = useIsAuthSelector();
   const userRole = useUserRoleSelector();
 
-  if (!productId) {
-    return renderRedirectComponent(productNotFoundRedirectConfig);
-  }
-
-  useEffect(() => {
-    if (isAuthenticated && userRole === ROLES.USER) {
+    useEffect(() => {
+    if (productId && isAuthenticated && userRole === ROLES.USER) {
       addViewProduct(productId);
     }
   }, [productId, isAuthenticated, addViewProduct, userRole]);
+
+  if (!productId) {
+    return renderRedirectComponent(productNotFoundRedirectConfig);
+  }
 
   return (
     <PageWrapper>

--- a/code/src/pages/product-details/ProductDetailsPage.tsx
+++ b/code/src/pages/product-details/ProductDetailsPage.tsx
@@ -5,12 +5,16 @@ import PageWrapper from "@/layouts/page-wrapper/PageWrapper";
 
 import AppBox from "@/components/app-box/AppBox";
 
+import { ROLES } from "@/constants/common";
 import useErrorPageRedirect from "@/hooks/use-error-page-redirect/useErrorPageRedirect";
 import { ProductDetailsPageParams } from "@/pages/product-details/ProductDetails.types";
 import { productNotFoundRedirectConfig } from "@/pages/product-details/ProductsDetailsPage.constants";
 import ProductDetailsContainer from "@/pages/product-details/components/product-details-container/ProductDetailsContainer";
 import { useUpdateViewedProductsMutation } from "@/store/api/viewHistoryApi";
-import { useIsAuthSelector } from "@/store/slices/userSlice";
+import {
+  useIsAuthSelector,
+  useUserRoleSelector
+} from "@/store/slices/userSlice";
 
 import "@/pages/product-details/ProductDetailsPage.scss";
 
@@ -19,15 +23,17 @@ const ProductDetailsPage = () => {
   const { renderRedirectComponent } = useErrorPageRedirect();
   const [addViewProduct] = useUpdateViewedProductsMutation();
   const isAuthenticated = useIsAuthSelector();
+  const userRole = useUserRoleSelector();
+
   if (!productId) {
     return renderRedirectComponent(productNotFoundRedirectConfig);
   }
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (isAuthenticated && userRole === ROLES.USER) {
       addViewProduct(productId);
     }
-  }, [productId, isAuthenticated, addViewProduct]);
+  }, [productId, isAuthenticated, addViewProduct, userRole]);
 
   return (
     <PageWrapper>

--- a/code/src/pages/product-details/ProductsDetailsPage.test.tsx
+++ b/code/src/pages/product-details/ProductsDetailsPage.test.tsx
@@ -1,10 +1,14 @@
 import { screen } from "@testing-library/react";
 import { useParams } from "react-router-dom";
 
+import { ROLES } from "@/constants/common";
 import ProductDetailsPage from "@/pages/product-details/ProductDetailsPage";
 import { productNotFoundRedirectConfig } from "@/pages/product-details/ProductsDetailsPage.constants";
 import { useUpdateViewedProductsMutation } from "@/store/api/viewHistoryApi";
-import { useIsAuthSelector } from "@/store/slices/userSlice";
+import {
+  useIsAuthSelector,
+  useUserRoleSelector
+} from "@/store/slices/userSlice";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
 
 const mockRenderRedirectComponent = jest.fn();
@@ -33,7 +37,8 @@ jest.mock(
   })
 );
 jest.mock("@/store/slices/userSlice", () => ({
-  useIsAuthSelector: jest.fn()
+  useIsAuthSelector: jest.fn(),
+  useUserRoleSelector: jest.fn()
 }));
 const addViewedProductMock = jest.fn();
 const renderAndMock = (productId?: string, isAuthenticated?: boolean) => {
@@ -42,6 +47,7 @@ const renderAndMock = (productId?: string, isAuthenticated?: boolean) => {
     addViewedProductMock
   ]);
   (useIsAuthSelector as jest.Mock).mockReturnValue(isAuthenticated);
+  (useUserRoleSelector as jest.Mock).mockReturnValue(ROLES.USER);
 
   renderWithProviders(<ProductDetailsPage />);
 };


### PR DESCRIPTION
### Description

When the user logs in as User, they will send a request to view history. When the user logs in as Admin or Manager, they will not see errors and will not send a request when viewing product details

https://github.com/user-attachments/assets/bd4776be-3d36-4deb-90b9-3c68a73cfd95



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Product views are now only recorded for authenticated users with the standard user role, preventing views from being recorded for admins or shop managers.

* **Tests**
  * Added and updated tests to verify that product views are only recorded for users with the standard user role.
  * Corrected test suite naming for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->