### PR TITLE
[GS3-72] Added Cypress tests for view history

### DIFF
--- a/code/src/components/product-card-with-delete/ProductCardWithDelete.tsx
+++ b/code/src/components/product-card-with-delete/ProductCardWithDelete.tsx
@@ -21,6 +21,7 @@ const ProductCardWithDelete = ({
         onClick={() => deleteViewProduct(productId)}
         aria-label="Delete product from view history"
         title="Delete product from view history"
+        data-cy='delete-product-from-history'
       >
         <DeleteOutlineOutlinedIcon fontSize="small" />
       </AppIconButton>

--- a/code/src/containers/modals/confirm-modal/ConfirmModal.tsx
+++ b/code/src/containers/modals/confirm-modal/ConfirmModal.tsx
@@ -56,7 +56,7 @@ const ConfirmModal = ({
         <AppButton onClick={handleClose} variant="danger" data-cy="close-button">
           <AppTypography translationKey={textCancel} />
         </AppButton>
-        <AppButton onClick={handleSave} data-cy="clear-button">
+        <AppButton onClick={handleSave} data-cy="save-button">
           <AppTypography translationKey={textSave} />
         </AppButton>
       </DialogActions>

--- a/code/src/containers/modals/confirm-modal/ConfirmModal.tsx
+++ b/code/src/containers/modals/confirm-modal/ConfirmModal.tsx
@@ -39,7 +39,8 @@ const ConfirmModal = ({
       onClose={handleClose}
       PaperProps={{
         className: styles.confirmModal,
-        "data-testid": "confirm-modal-paper"
+        "data-testid": "confirm-modal-paper",
+        "data-cy": "confirm-modal"
       }}
     >
       <AppTypography variant="h3" translationKey={title} />
@@ -52,10 +53,10 @@ const ConfirmModal = ({
       </AppIconButton>
       {description && <AppTypography translationKey={description} />}
       <DialogActions>
-        <AppButton onClick={handleClose} variant="danger">
+        <AppButton onClick={handleClose} variant="danger" data-cy="close-button">
           <AppTypography translationKey={textCancel} />
         </AppButton>
-        <AppButton onClick={handleSave}>
+        <AppButton onClick={handleSave} data-cy="clear-button">
           <AppTypography translationKey={textSave} />
         </AppButton>
       </DialogActions>

--- a/code/src/containers/user-account/view-history/UserViewHistory.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.tsx
@@ -103,7 +103,10 @@ const UserViewHistory = () => {
 
     if (viewHistoryResponse?.content.length === 0 && !isLoading) {
       return (
-        <AppBox className={styles.viewHistory_fallback}>
+        <AppBox
+          className={styles.viewHistory_fallback}
+          data-cy="view-history-fallback"
+        >
           <SentimentDissatisfiedOutlinedIcon fontSize="large" />
           <AppTypography
             variant="h3"
@@ -125,17 +128,23 @@ const UserViewHistory = () => {
   return (
     <AppBox className={styles.viewHistory}>
       <AppBox className={styles.viewHistory_header}>
-        <AppTypography variant="h3" translationKey="userViewHistory.title" />
+        <AppTypography
+          variant="h3"
+          translationKey="userViewHistory.title"
+          data-cy="view-history-title"
+        />
         <AppButton
           className={styles.viewHistory_header__btn}
           variant="contained"
           size="medium"
           onClick={onDeleteAll}
+          data-cy="delete-all-products"
         >
           <AppTypography translationKey="userViewHistory.clearAll" />
         </AppButton>
         <AppTypography component="span">
           <AppTypography
+            data-cy="products-count"
             translationKey="userViewHistory.productsLabel"
             component="span"
             translationProps={{

--- a/e2e/cypress/test_module/cypress/features/user-profile/view-history/view-history-page.feature
+++ b/e2e/cypress/test_module/cypress/features/user-profile/view-history/view-history-page.feature
@@ -3,30 +3,39 @@ Feature: View History
     Background:
         Given I authenticate to the system under role ROLE_USER
 
+    @GS3-72
     Scenario: Removing a single product from view history
         Given The view history page is loaded with 1 products
-        When The user clicks the delete icon on that product card
+        When The user clicks the delete icon on first product card
         And The view history page is loaded with an empty list
-        Then The product card should no longer be visible
         And The product count should show "0 viewed products"
         And The fallback should be shown
 
+    @GS3-72
     Scenario: Delete all products from view history
         Given The view history page is loaded with 3 products
         When The user clicks Clear All button
-        Then Modal confirm should be visible
-        When The user clicks Close button
-        Then Modal confirm should NOT be visible
-        When The user clicks Clear All button
+        Then Modal confirm should be "visible"
         And The user clicks Clear button in modal
         Then The fallback should be shown
 
+    @GS3-72
+    Scenario: Modal confirm is shown when user clicks Clear All button
+        Given The view history page is loaded with 1 products
+        When The user clicks Clear All button
+        Then Modal confirm should be "visible"
+        When The user clicks Close button
+        Then Modal confirm should be "not visible"
+        When The user clicks Clear All button
+
+    @GS3-72
     Scenario: Fallback is shown when view history is empty
         Given The view history page is loaded with an empty list
         Then The fallback should be shown
 
 
 
+    @GS3-72
     Scenario Outline: Verify sorting options are present and visible
         Given The view history page is loaded with an empty list
         When The user clicks the sort dropdown

--- a/e2e/cypress/test_module/cypress/features/user-profile/view-history/view-history-page.feature
+++ b/e2e/cypress/test_module/cypress/features/user-profile/view-history/view-history-page.feature
@@ -1,0 +1,38 @@
+Feature: View History
+
+    Background:
+        Given I authenticate to the system under role ROLE_USER
+
+    Scenario: Removing a single product from view history
+        Given The view history page is loaded with 1 products
+        When The user clicks the delete icon on that product card
+        And The view history page is loaded with an empty list
+        Then The product card should no longer be visible
+        And The product count should show "0 viewed products"
+        And The fallback should be shown
+
+    Scenario: Delete all products from view history
+        Given The view history page is loaded with 3 products
+        When The user clicks Clear All button
+        Then Modal confirm should be visible
+        When The user clicks Close button
+        Then Modal confirm should NOT be visible
+        When The user clicks Clear All button
+        And The user clicks Clear button in modal
+        Then The fallback should be shown
+
+    Scenario: Fallback is shown when view history is empty
+        Given The view history page is loaded with an empty list
+        Then The fallback should be shown
+
+
+
+    Scenario Outline: Verify sorting options are present and visible
+        Given The view history page is loaded with an empty list
+        When The user clicks the sort dropdown
+        Then The "<criteria>" option should be visible
+
+        Examples:
+            | criteria |
+            | Newest   |
+            | Oldest   |

--- a/e2e/cypress/test_module/cypress/support/commands.ts
+++ b/e2e/cypress/test_module/cypress/support/commands.ts
@@ -43,7 +43,7 @@ Cypress.Commands.add("loginWithRole", (role = "ROLE_USER") => {
   const email = Cypress.env(`${role}_EMAIL`);
   const password = Cypress.env(`${role}_PASSWORD`);
 
-  cy.intercept("POST", "/retail/auth/sign-in").as("loginRequest");
+  cy.intercept("POST", "/api/auth/sign-in").as("loginRequest");
 
   cy.visitWithLanguage("/");
   cy.getById("auth-button").click();

--- a/e2e/cypress/test_module/cypress/support/commands.ts
+++ b/e2e/cypress/test_module/cypress/support/commands.ts
@@ -43,7 +43,9 @@ Cypress.Commands.add("loginWithRole", (role = "ROLE_USER") => {
   const email = Cypress.env(`${role}_EMAIL`);
   const password = Cypress.env(`${role}_PASSWORD`);
 
-  cy.intercept("POST", "/api/auth/sign-in").as("loginRequest");
+  cy.intercept( httpMethod.post, "**/auth/sign-in*" ).as(
+    "loginRequest"
+  );
 
   cy.visitWithLanguage("/");
   cy.getById("auth-button").click();

--- a/e2e/cypress/test_module/cypress/support/helpers.ts
+++ b/e2e/cypress/test_module/cypress/support/helpers.ts
@@ -8,3 +8,27 @@ export const checkUserDetailsInLocalStorage = (
   expect(userDetails.token).to.exist;
   expect(userDetails.role).to.eq(role);
 };
+
+const createMockProducts = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `product-id-${index + 1}`,
+    name: `Product ${index + 1}`,
+    image: "...",
+    price: 1000.0,
+    priceWithDiscount: 800.0
+  }));
+
+export const interceptGetProducts = (
+  path: string | RegExp,
+  count: number = 0,
+  alias: string = "getProducts"
+) => {
+  const mockResponse = {
+    totalElements: count,
+    content: createMockProducts(count)
+  };
+
+  cy.intercept("GET", path, {
+    body: mockResponse
+  }).as(alias);
+};

--- a/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
@@ -1,0 +1,112 @@
+import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
+
+const mockViewHistoryWithProduct = {
+  totalElements: 1,
+  content: [
+    {
+      id: "39159d74-f9f7-4136-bd7e-f006b34f8cb4",
+      name: "Apple iPhone 13 128GB Red Mobile Phone",
+      image: "...",
+      price: 1000.0,
+      priceWithDiscount: 800.0
+    }
+  ]
+};
+
+const mockViewHistoryEmpty = {
+  totalElements: 0,
+  content: []
+};
+
+Given(
+  "The view history page is loaded with {int} product(s)",
+  (productCount: number) => {
+    const products = Array.from({ length: productCount }, (_, index) => ({
+      id: `product-id-${index + 1}`,
+      name: `Product ${index + 1}`,
+      image: "...",
+      price: 1000.0,
+      priceWithDiscount: 800.0 + index * 10
+    }));
+
+    const mockViewHistory = {
+      totalElements: productCount,
+      content: products
+    };
+
+    cy.intercept("GET", "**/retail/v1/my-view-history*", {
+      body: mockViewHistory
+    }).as("getViewHistory");
+
+    cy.visit("/user-cabinet/view-history");
+    cy.wait("@getViewHistory");
+  }
+);
+
+When("The user clicks the delete icon on that product card", () => {
+  cy.intercept("DELETE", "**/retail/v1/my-view-history/*", {
+    statusCode: 204
+  }).as("deleteProduct");
+  cy.get('[data-cy="delete-product-from-history"]').first().click();
+
+  cy.wait("@deleteProduct");
+});
+
+Given("The view history page is loaded with an empty list", () => {
+  cy.intercept("GET", "**/retail/v1/my-view-history*", {
+    body: mockViewHistoryEmpty
+  }).as("getEmptyViewHistory");
+
+  cy.visit("/user-cabinet/view-history");
+  cy.wait("@getEmptyViewHistory");
+});
+
+Then("The product card should no longer be visible", () => {
+  cy.get('[data-cy="product-card"]').should("not.exist");
+});
+
+Then("The product count should show {string}", (countText: string) => {
+  cy.get('[data-cy="products-count"]').should("contain", countText);
+});
+
+Then("The fallback should be shown", () => {
+  cy.get('[data-cy="view-history-fallback"]').should("be.visible");
+});
+
+When("The user clicks the sort dropdown", () => {
+  cy.get('[data-cy="products-dropdown"]').click();
+});
+
+Then("The {string} option should be visible", (criteria: string) => {
+  cy.contains(criteria).should("be.visible");
+});
+
+When("The user clicks Clear All button", () => {
+  cy.get('[data-cy="delete-all-products"]').click();
+});
+
+Then("Modal confirm should be visible", () => {
+  cy.get('[data-cy="confirm-modal"]').should("be.visible");
+});
+
+Then("Modal confirm should NOT be visible", () => {
+  cy.get('[data-cy="confirm-modal"]').should("not.exist");
+});
+
+Then("The user clicks Close button", () => {
+  cy.get('[data-cy="close-button"]').click();
+});
+
+Then("The user clicks Clear button in modal", () => {
+  cy.intercept("DELETE", "**/retail/v1/my-view-history", {
+    statusCode: 204
+  }).as("deleteAllProducts");
+
+  cy.intercept("GET", "**/retail/v1/my-view-history*", {
+    body: mockViewHistoryEmpty
+  }).as("getEmptyViewHistory");
+
+  cy.get('[data-cy="clear-button"]').click();
+  cy.wait("@deleteAllProducts");
+  cy.wait("@getEmptyViewHistory");
+});

--- a/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
@@ -38,10 +38,6 @@ Given("The view history page is loaded with an empty list", () => {
   cy.wait("@getEmptyViewHistory");
 });
 
-Then("The product card should no longer be visible", () => {
-  cy.get('[data-cy="product-card"]').should("not.exist");
-});
-
 Then("The product count should show {string}", (countText: string) => {
   cy.get('[data-cy="products-count"]').should("contain", countText);
 });

--- a/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
@@ -1,42 +1,34 @@
 import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
 
-const mockViewHistoryWithProduct = {
-  totalElements: 1,
-  content: [
-    {
-      id: "39159d74-f9f7-4136-bd7e-f006b34f8cb4",
-      name: "Apple iPhone 13 128GB Red Mobile Phone",
-      image: "...",
-      price: 1000.0,
-      priceWithDiscount: 800.0
-    }
-  ]
-};
-
 const mockViewHistoryEmpty = {
   totalElements: 0,
   content: []
 };
 
+const createMockProducts = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `product-id-${index + 1}`,
+    name: `Product ${index + 1}`,
+    image: "...",
+    price: 1000.0,
+    priceWithDiscount: 800.0
+  }));
+
+const interceptViewHistoryWithProducts = (count: number) => {
+  const mockViewHistory = {
+    totalElements: count,
+    content: createMockProducts(count)
+  };
+
+  cy.intercept("GET", "**/retail/v1/my-view-history*", {
+    body: mockViewHistory
+  }).as("getViewHistory");
+};
+
 Given(
   "The view history page is loaded with {int} product(s)",
-  (productCount: number) => {
-    const products = Array.from({ length: productCount }, (_, index) => ({
-      id: `product-id-${index + 1}`,
-      name: `Product ${index + 1}`,
-      image: "...",
-      price: 1000.0,
-      priceWithDiscount: 800.0 + index * 10
-    }));
-
-    const mockViewHistory = {
-      totalElements: productCount,
-      content: products
-    };
-
-    cy.intercept("GET", "**/retail/v1/my-view-history*", {
-      body: mockViewHistory
-    }).as("getViewHistory");
+  (count: number) => {
+    interceptViewHistoryWithProducts(count);
 
     cy.visit("/user-cabinet/view-history");
     cy.wait("@getViewHistory");

--- a/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
@@ -1,43 +1,27 @@
 import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
 import { httpMethod } from "@cypress-e2e/fixtures/global-data";
+import { interceptGetProducts } from "../helpers";
 
 const mockViewHistoryEmpty = {
   totalElements: 0,
   content: []
 };
 
-const createMockProducts = (count: number) =>
-  Array.from({ length: count }, (_, index) => ({
-    id: `product-id-${index + 1}`,
-    name: `Product ${index + 1}`,
-    image: "...",
-    price: 1000.0,
-    priceWithDiscount: 800.0
-  }));
-
-const interceptViewHistoryWithProducts = (count: number) => {
-  const mockViewHistory = {
-    totalElements: count,
-    content: createMockProducts(count)
-  };
-
-  cy.intercept(httpMethod.get, /\/api\/v1\/my-view-history/, {
-    body: mockViewHistory
-  }).as("getViewHistory");
-};
+const viewHistoryRequestPath = /\/api\/v1\/my-view-history/;
+const viewHistoryPath = "/user-cabinet/view-history";
 
 Given(
   "The view history page is loaded with {int} product(s)",
   (count: number) => {
-    interceptViewHistoryWithProducts(count);
+    interceptGetProducts(viewHistoryRequestPath, count, "getViewHistory");
 
-    cy.visit("/user-cabinet/view-history");
+    cy.visit(viewHistoryPath);
     cy.wait("@getViewHistory");
   }
 );
 
-When("The user clicks the delete icon on that product card", () => {
-  cy.intercept(httpMethod.delete, /\/api\/v1\/my-view-history/, {
+When("The user clicks the delete icon on first product card", () => {
+  cy.intercept(httpMethod.delete, viewHistoryRequestPath, {
     statusCode: 204
   }).as("deleteProduct");
   cy.get('[data-cy="delete-product-from-history"]').first().click();
@@ -46,11 +30,11 @@ When("The user clicks the delete icon on that product card", () => {
 });
 
 Given("The view history page is loaded with an empty list", () => {
-  cy.intercept(httpMethod.get, /\/api\/v1\/my-view-history/, {
+  cy.intercept(httpMethod.get, viewHistoryRequestPath, {
     body: mockViewHistoryEmpty
   }).as("getEmptyViewHistory");
 
-  cy.visit("/user-cabinet/view-history");
+  cy.visit(viewHistoryPath);
   cy.wait("@getEmptyViewHistory");
 });
 
@@ -70,20 +54,18 @@ When("The user clicks the sort dropdown", () => {
   cy.get('[data-cy="products-dropdown"]').click();
 });
 
-Then("The {string} option should be visible", (criteria: string) => {
-  cy.contains(criteria).should("be.visible");
+Then("The {string} option should be visible", (text: string) => {
+  cy.contains('[data-cy="dropdown-item"]', text).should("be.visible");
 });
 
 When("The user clicks Clear All button", () => {
   cy.get('[data-cy="delete-all-products"]').click();
 });
 
-Then("Modal confirm should be visible", () => {
-  cy.get('[data-cy="confirm-modal"]').should("be.visible");
-});
+Then("Modal confirm should be {string}", (visibility) => {
+  const assertion = visibility === "visible" ? "be.visible" : "not.exist";
 
-Then("Modal confirm should NOT be visible", () => {
-  cy.get('[data-cy="confirm-modal"]').should("not.exist");
+  cy.get('[data-cy="confirm-modal"]').should(assertion);
 });
 
 Then("The user clicks Close button", () => {
@@ -91,15 +73,15 @@ Then("The user clicks Close button", () => {
 });
 
 Then("The user clicks Clear button in modal", () => {
-  cy.intercept(httpMethod.delete, /\/api\/v1\/my-view-history/, {
+  cy.intercept(httpMethod.delete, viewHistoryRequestPath, {
     statusCode: 204
   }).as("deleteAllProducts");
 
-  cy.intercept(httpMethod.get, /\/api\/v1\/my-view-history/, {
+  cy.intercept(httpMethod.get, viewHistoryRequestPath, {
     body: mockViewHistoryEmpty
   }).as("getEmptyViewHistory");
 
-  cy.get('[data-cy="clear-button"]').click();
+  cy.get('[data-cy="save-button"]').click();
   cy.wait("@deleteAllProducts");
   cy.wait("@getEmptyViewHistory");
 });

--- a/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/view-history.steps.ts
@@ -1,4 +1,5 @@
 import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
+import { httpMethod } from "@cypress-e2e/fixtures/global-data";
 
 const mockViewHistoryEmpty = {
   totalElements: 0,
@@ -20,7 +21,7 @@ const interceptViewHistoryWithProducts = (count: number) => {
     content: createMockProducts(count)
   };
 
-  cy.intercept("GET", "**/retail/v1/my-view-history*", {
+  cy.intercept(httpMethod.get, /\/api\/v1\/my-view-history/, {
     body: mockViewHistory
   }).as("getViewHistory");
 };
@@ -36,7 +37,7 @@ Given(
 );
 
 When("The user clicks the delete icon on that product card", () => {
-  cy.intercept("DELETE", "**/retail/v1/my-view-history/*", {
+  cy.intercept(httpMethod.delete, /\/api\/v1\/my-view-history/, {
     statusCode: 204
   }).as("deleteProduct");
   cy.get('[data-cy="delete-product-from-history"]').first().click();
@@ -45,7 +46,7 @@ When("The user clicks the delete icon on that product card", () => {
 });
 
 Given("The view history page is loaded with an empty list", () => {
-  cy.intercept("GET", "**/retail/v1/my-view-history*", {
+  cy.intercept(httpMethod.get, /\/api\/v1\/my-view-history/, {
     body: mockViewHistoryEmpty
   }).as("getEmptyViewHistory");
 
@@ -90,11 +91,11 @@ Then("The user clicks Close button", () => {
 });
 
 Then("The user clicks Clear button in modal", () => {
-  cy.intercept("DELETE", "**/retail/v1/my-view-history", {
+  cy.intercept(httpMethod.delete, /\/api\/v1\/my-view-history/, {
     statusCode: 204
   }).as("deleteAllProducts");
 
-  cy.intercept("GET", "**/retail/v1/my-view-history*", {
+  cy.intercept(httpMethod.get, /\/api\/v1\/my-view-history/, {
     body: mockViewHistoryEmpty
   }).as("getEmptyViewHistory");
 


### PR DESCRIPTION
### Description 

<img width="503" height="268" alt="image" src="https://github.com/user-attachments/assets/ea578ce5-20f8-4bf0-8bf4-6f17e0b109f8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for the view history page covering single delete, clear all, modal behavior, fallback UI, and sorting options.
  * Added step definitions and supporting scenarios to drive those view-history tests and assertions.
* **Chores**
  * Added stable test selectors to view history and confirmation UI to improve test reliability.
  * Added test helpers to mock product lists and made login request interception more flexible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->