### PR TITLE
[GS3-86] Fixed text color when input disabled

### DIFF
--- a/code/src/components/app-input/AppInput.scss
+++ b/code/src/components/app-input/AppInput.scss
@@ -52,6 +52,11 @@ $spa-input-colors: (
           .MuiOutlinedInput-notchedOutline {
             border-color: var(--color-muted) !important;
           }
+
+          input {
+            -webkit-text-fill-color: var(--color-muted);
+            color: var(--color-muted) !important;
+          }
         }
       }
       .MuiInputLabel-root {


### PR DESCRIPTION
### Description 

**Dark theme**

<img width="519" height="77" alt="image" src="https://github.com/user-attachments/assets/ab7c340d-77dd-4c57-bd46-9a037a696bae" />


**Light theme**

<img width="519" height="80" alt="image" src="https://github.com/user-attachments/assets/a4f24e92-4d93-4ceb-ac1b-7e3395e51ff4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of disabled input fields to ensure their text color displays in a muted tone for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->