### PR TITLE
[GS3-89] Added modal for updating profile img URL

### DIFF
--- a/code/src/constants/requests.ts
+++ b/code/src/constants/requests.ts
@@ -91,7 +91,10 @@ export const URLS = {
   },
   userInfo: {
     getUserInfo: "/v2/my-info",
-    patchUserInfo: "/v2/my-info"
+    patchUserInfo: "/v2/my-info",
+    photo: {
+      put: "/v1/my-info/photo"
+    }
   },
   viewHistory: {
     get: "/v1/my-view-history",

--- a/code/src/containers/modals/add-link/AddLinkModal.consts.ts
+++ b/code/src/containers/modals/add-link/AddLinkModal.consts.ts
@@ -1,5 +1,6 @@
 type AddLinkFormValues = { photoURL: string };
 
-export const defaultValues: AddLinkFormValues = {
+export const defaultValues: Readonly<AddLinkFormValues> = Object.freeze({
   photoURL: ""
-};
+});
+

--- a/code/src/containers/modals/add-link/AddLinkModal.consts.ts
+++ b/code/src/containers/modals/add-link/AddLinkModal.consts.ts
@@ -1,0 +1,5 @@
+type AddLinkFormValues = { photoURL: string };
+
+export const defaultValues: AddLinkFormValues = {
+  photoURL: ""
+};

--- a/code/src/containers/modals/add-link/AddLinkModal.module.scss
+++ b/code/src/containers/modals/add-link/AddLinkModal.module.scss
@@ -1,0 +1,26 @@
+@import "@design-system";
+
+.addLinkModal {
+  display: flex;
+  flex-direction: column;
+  gap: spacing(4);
+  padding: spacing(7);
+  position: relative;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  border-radius: spacing(1);
+
+  &_closeIcon {
+    position: absolute;
+    top: spacing(2);
+    right: spacing(2);
+    cursor: pointer;
+    color: inherit;
+  }
+
+  &_buttonsContainer {
+    display: flex;
+    align-self: flex-end;
+    gap: spacing(2);
+  }
+}

--- a/code/src/containers/modals/add-link/AddLinkModal.test.tsx
+++ b/code/src/containers/modals/add-link/AddLinkModal.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import userEvent from "@testing-library/user-event";
+
+import { useModalContext } from "@/context/modal/ModalContext";
+import { useUpdateUserPhotoMutation } from "@/store/api/userProfileApi";
+
+import AddLinkModal from "./AddLinkModal";
+
+const mockupdateUserPhotoURL = jest.fn();
+const mockCloseModal = jest.fn();
+
+jest.mock("@/context/modal/ModalContext");
+jest.mock("@/store/api/userProfileApi");
+(useModalContext as jest.Mock).mockReturnValue({
+  closeModal: mockCloseModal
+});
+
+const renderAndMock = ({ isLoading = false } = {}) => {
+  (useUpdateUserPhotoMutation as jest.Mock).mockReturnValue([
+    mockupdateUserPhotoURL,
+    { isLoading }
+  ]);
+  render(<AddLinkModal />);
+};
+
+const mockPhotoURL = "https://example.com/photo.jpg";
+
+describe("AddLinkModal", () => {
+  beforeEach(() => {
+    renderAndMock();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should render the modal with correctly", () => {
+    const title = screen.getByText("addLink.title");
+    const saveButton = screen.getByText("addLink.saveButton");
+
+    expect(title).toBeInTheDocument();
+    expect(saveButton).toBeInTheDocument();
+  });
+
+  it("should show validation error when no URL", async () => {
+    const saveButton = screen.getByText("addLink.saveButton");
+
+    await userEvent.click(saveButton);
+
+    const inputError = screen.getByText("addLink.error.required");
+    expect(inputError).toBeInTheDocument();
+    expect(mockupdateUserPhotoURL).not.toHaveBeenCalled();
+  });
+
+  it("should successfully update photo when valid URL", async () => {
+    const saveButton = screen.getByText("addLink.saveButton");
+    const input = screen.getByLabelText("addLink.inputLabel");
+
+    await userEvent.type(input, mockPhotoURL);
+    await userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockupdateUserPhotoURL).toHaveBeenCalledTimes(1);
+      expect(mockupdateUserPhotoURL).toHaveBeenCalledWith({
+        photo: mockPhotoURL
+      });
+    });
+  });
+});

--- a/code/src/containers/modals/add-link/AddLinkModal.test.tsx
+++ b/code/src/containers/modals/add-link/AddLinkModal.test.tsx
@@ -70,7 +70,7 @@ describe("AddLinkModal", () => {
 
   it("should close when clicking the Close button", async () => {
     renderAndMock();
-    
+
     const closeBtn = screen.getByText("addLink.closeButton");
     await userEvent.click(closeBtn);
 
@@ -81,5 +81,14 @@ describe("AddLinkModal", () => {
 
     const saveButton = screen.getByText("addLink.saveButton").closest("button");
     expect(saveButton).toBeDisabled();
+  });
+
+  it("should render the close button with the correct aria-label", () => {
+    renderAndMock();
+
+    const closeButton = screen.getByTestId("CloseIcon").parentNode;
+
+    expect(closeButton).toBeInTheDocument();
+    expect(closeButton).toHaveAttribute("aria-label", "addLink.closeButton");
   });
 });

--- a/code/src/containers/modals/add-link/AddLinkModal.test.tsx
+++ b/code/src/containers/modals/add-link/AddLinkModal.test.tsx
@@ -7,7 +7,7 @@ import { useUpdateUserPhotoMutation } from "@/store/api/userProfileApi";
 
 import AddLinkModal from "./AddLinkModal";
 
-const mockupdateUserPhotoURL = jest.fn();
+const mockUpdateUserPhotoURL = jest.fn();
 const mockCloseModal = jest.fn();
 
 jest.mock("@/context/modal/ModalContext");
@@ -16,10 +16,10 @@ jest.mock("@/store/api/userProfileApi");
   closeModal: mockCloseModal
 });
 
-const renderAndMock = ({ isLoading = false } = {}) => {
+const renderAndMock = ({ isLoading = false, isSuccess = false } = {}) => {
   (useUpdateUserPhotoMutation as jest.Mock).mockReturnValue([
-    mockupdateUserPhotoURL,
-    { isLoading }
+    mockUpdateUserPhotoURL,
+    { isLoading, isSuccess }
   ]);
   render(<AddLinkModal />);
 };
@@ -27,14 +27,12 @@ const renderAndMock = ({ isLoading = false } = {}) => {
 const mockPhotoURL = "https://example.com/photo.jpg";
 
 describe("AddLinkModal", () => {
-  beforeEach(() => {
-    renderAndMock();
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
-  it("should render the modal with correctly", () => {
+
+  it("should render the modal correctly", () => {
+    renderAndMock();
     const title = screen.getByText("addLink.title");
     const saveButton = screen.getByText("addLink.saveButton");
 
@@ -43,16 +41,18 @@ describe("AddLinkModal", () => {
   });
 
   it("should show validation error when no URL", async () => {
+    renderAndMock();
     const saveButton = screen.getByText("addLink.saveButton");
 
     await userEvent.click(saveButton);
 
     const inputError = screen.getByText("addLink.error.required");
     expect(inputError).toBeInTheDocument();
-    expect(mockupdateUserPhotoURL).not.toHaveBeenCalled();
+    expect(mockUpdateUserPhotoURL).not.toHaveBeenCalled();
   });
 
   it("should successfully update photo when valid URL", async () => {
+    renderAndMock({ isSuccess: true });
     const saveButton = screen.getByText("addLink.saveButton");
     const input = screen.getByLabelText("addLink.inputLabel");
 
@@ -60,10 +60,26 @@ describe("AddLinkModal", () => {
     await userEvent.click(saveButton);
 
     await waitFor(() => {
-      expect(mockupdateUserPhotoURL).toHaveBeenCalledTimes(1);
-      expect(mockupdateUserPhotoURL).toHaveBeenCalledWith({
+      expect(mockUpdateUserPhotoURL).toHaveBeenCalledTimes(1);
+      expect(mockUpdateUserPhotoURL).toHaveBeenCalledWith({
         photo: mockPhotoURL
       });
+      expect(mockCloseModal).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("should close when clicking the Close button", async () => {
+    renderAndMock();
+    
+    const closeBtn = screen.getByText("addLink.closeButton");
+    await userEvent.click(closeBtn);
+
+    expect(mockCloseModal).toHaveBeenCalledTimes(1);
+  });
+  it("should disable Save and show loading state while isLoading", async () => {
+    renderAndMock({ isLoading: true });
+
+    const saveButton = screen.getByText("addLink.saveButton").closest("button");
+    expect(saveButton).toBeDisabled();
   });
 });

--- a/code/src/containers/modals/add-link/AddLinkModal.tsx
+++ b/code/src/containers/modals/add-link/AddLinkModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
 
@@ -22,7 +23,8 @@ import * as styles from "@/containers/modals/add-link/AddLinkModal.module.scss";
 const AddLinkModal = () => {
   const { closeModal } = useModalContext();
   const { formatMessage } = useIntl();
-  const [updateUserPhotoURL, { isLoading }] = useUpdateUserPhotoMutation();
+  const [updateUserPhotoURL, { isLoading, isSuccess }] =
+    useUpdateUserPhotoMutation();
   const {
     register,
     handleSubmit,
@@ -34,9 +36,14 @@ const AddLinkModal = () => {
     }
   });
 
+  useEffect(() => {
+    if (isSuccess) {
+      closeModal();
+    }
+  }, [isSuccess, closeModal]);
+
   const onSubmit = (data: AddLinkValidatorType) => {
     updateUserPhotoURL({ photo: data.photoURL });
-    closeModal();
   };
 
   return (
@@ -50,6 +57,7 @@ const AddLinkModal = () => {
         onClick={closeModal}
         className={styles.addLinkModal_closeIcon}
         type="button"
+        aria-label={formatMessage({ id: "addLink.closeButton" })}
       >
         <CloseIcon />
       </AppIconButton>
@@ -65,12 +73,14 @@ const AddLinkModal = () => {
         }
         labelTranslationKey="addLink.inputLabel"
         data-cy="URL-input"
+        type="url"
+        autoFocus
       />
       <AppBox className={styles.addLinkModal_buttonsContainer}>
         <AppButton type="button" onClick={closeModal} variant="danger">
           <AppTypography translationKey="addLink.closeButton" />
         </AppButton>
-        <AppButton type="submit" isLoading={isLoading}>
+        <AppButton type="submit" isLoading={isLoading} disabled={isLoading}>
           <AppTypography translationKey="addLink.saveButton" />
         </AppButton>
       </AppBox>

--- a/code/src/containers/modals/add-link/AddLinkModal.tsx
+++ b/code/src/containers/modals/add-link/AddLinkModal.tsx
@@ -1,0 +1,81 @@
+import { useForm } from "react-hook-form";
+import { useIntl } from "react-intl";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import CloseIcon from "@mui/icons-material/Close";
+
+import AppBox from "@/components/app-box/AppBox";
+import AppButton from "@/components/app-button/AppButton";
+import AppIconButton from "@/components/app-icon-button/AppIconButton";
+import AppInput from "@/components/app-input/AppInput";
+import AppTypography from "@/components/app-typography/AppTypography";
+
+import { useModalContext } from "@/context/modal/ModalContext";
+import { useUpdateUserPhotoMutation } from "@/store/api/userProfileApi";
+import {
+  AddLinkValidationSchema,
+  AddLinkValidatorType
+} from "@/utils/validators/photoScheme";
+
+import * as styles from "@/containers/modals/add-link/AddLinkModal.module.scss";
+
+const AddLinkModal = () => {
+  const { closeModal } = useModalContext();
+  const { formatMessage } = useIntl();
+  const [updateUserPhotoURL, { isLoading }] = useUpdateUserPhotoMutation();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<AddLinkValidatorType>({
+    resolver: zodResolver(AddLinkValidationSchema),
+    defaultValues: {
+      photoURL: ""
+    }
+  });
+
+  const onSubmit = (data: AddLinkValidatorType) => {
+    updateUserPhotoURL({ photo: data.photoURL });
+    closeModal();
+  };
+
+  return (
+    <AppBox
+      className={styles.addLinkModal}
+      component="form"
+      onSubmit={handleSubmit(onSubmit)}
+      data-cy="add-link-modal"
+    >
+      <AppIconButton
+        onClick={closeModal}
+        className={styles.addLinkModal_closeIcon}
+        type="button"
+      >
+        <CloseIcon />
+      </AppIconButton>
+      <AppTypography variant="h3" translationKey="addLink.title" />
+      <AppTypography translationKey="addLink.description" />
+      <AppInput
+        {...register("photoURL")}
+        error={Boolean(errors.photoURL)}
+        helperText={
+          errors.photoURL
+            ? formatMessage({ id: errors.photoURL.message })
+            : undefined
+        }
+        labelTranslationKey="addLink.inputLabel"
+        data-cy="URL-input"
+      />
+      <AppBox className={styles.addLinkModal_buttonsContainer}>
+        <AppButton type="button" onClick={closeModal} variant="danger">
+          <AppTypography translationKey="addLink.closeButton" />
+        </AppButton>
+        <AppButton type="submit" isLoading={isLoading}>
+          <AppTypography translationKey="addLink.saveButton" />
+        </AppButton>
+      </AppBox>
+    </AppBox>
+  );
+};
+
+export default AddLinkModal;

--- a/code/src/containers/modals/add-link/AddLinkModal.tsx
+++ b/code/src/containers/modals/add-link/AddLinkModal.tsx
@@ -5,6 +5,8 @@ import { useIntl } from "react-intl";
 import { zodResolver } from "@hookform/resolvers/zod";
 import CloseIcon from "@mui/icons-material/Close";
 
+import { defaultValues } from "@/containers/modals/add-link/AddLinkModal.consts";
+
 import AppBox from "@/components/app-box/AppBox";
 import AppButton from "@/components/app-button/AppButton";
 import AppIconButton from "@/components/app-icon-button/AppIconButton";
@@ -31,9 +33,7 @@ const AddLinkModal = () => {
     formState: { errors }
   } = useForm<AddLinkValidatorType>({
     resolver: zodResolver(AddLinkValidationSchema),
-    defaultValues: {
-      photoURL: ""
-    }
+    defaultValues: defaultValues
   });
 
   useEffect(() => {

--- a/code/src/containers/modals/add-link/messages/en.json
+++ b/code/src/containers/modals/add-link/messages/en.json
@@ -1,0 +1,10 @@
+{
+  "addLink.title": "Add a Link",
+  "addLink.description": "Paste the URL of an image you would like to use as your profile photo.",
+  "addLink.inputLabel": "Image URL",
+  "addLink.saveButton": "Save",
+  "addLink.closeButton": "Close",
+  "addLink.error.invalidUrl": "Please enter a valid URL.",
+  "addLink.error.network": "Network error, please try again later.",
+  "addLink.error.required": "This field is required."
+}

--- a/code/src/containers/modals/add-link/messages/en.json
+++ b/code/src/containers/modals/add-link/messages/en.json
@@ -5,6 +5,5 @@
   "addLink.saveButton": "Save",
   "addLink.closeButton": "Close",
   "addLink.error.invalidUrl": "Please enter a valid URL.",
-  "addLink.error.network": "Network error, please try again later.",
   "addLink.error.required": "This field is required."
 }

--- a/code/src/containers/modals/add-link/messages/index.ts
+++ b/code/src/containers/modals/add-link/messages/index.ts
@@ -1,0 +1,4 @@
+import en from "@/containers/modals/add-link/messages/en.json";
+import uk from "@/containers/modals/add-link/messages/uk.json";
+
+export default { en, uk };

--- a/code/src/containers/modals/add-link/messages/uk.json
+++ b/code/src/containers/modals/add-link/messages/uk.json
@@ -1,0 +1,9 @@
+{
+  "addLink.title": "Додати посилання",
+  "addLink.description": "Вставте URL-адресу зображення, яке ви хочете використовувати як фотографію профілю.",
+  "addLink.inputLabel": "URL-адреса зображення",
+  "addLink.saveButton": "Зберегти",
+  "addLink.closeButton": "Закрити",
+  "addLink.error.invalidUrl": "Будь ласка, введіть дійсну URL-адресу.",
+  "addLink.error.required": "Це поле обов'язкове."
+}

--- a/code/src/containers/modals/user-account/EditPersonalInfoModal.tsx
+++ b/code/src/containers/modals/user-account/EditPersonalInfoModal.tsx
@@ -89,7 +89,6 @@ const EditPersonalInfoModal = ({
           labelTranslationKey="personalInfo.firstname"
           autoComplete="given-name"
           data-cy="firstname"
-          // className={styles.personalInfoModal_inputs}
         />
         <AppInput
           {...register("lastName")}
@@ -102,7 +101,6 @@ const EditPersonalInfoModal = ({
           labelTranslationKey="personalInfo.lastname"
           autoComplete="family-name"
           data-cy="lastname"
-          // className={styles.personalInfoModal_inputs}
         />
         <AppInput
           {...register("phone")}
@@ -116,7 +114,6 @@ const EditPersonalInfoModal = ({
           autoComplete="tel"
           data-cy="phone-number"
           type="tel"
-          // className={styles.personalInfoModal_inputs}
         />
       </AppBox>
       <AppButton

--- a/code/src/messages.ts
+++ b/code/src/messages.ts
@@ -13,6 +13,7 @@ import productFormMessages from "@/containers/forms/product-form/messages";
 import signInFormMessages from "@/containers/forms/sign-in-form/messages";
 import signupFormMessages from "@/containers/forms/sign-up-form/messages";
 import bannerMessages from "@/containers/intro-banner/messages";
+import addLinkModalMessages from "@/containers/modals/add-link/messages";
 import authModalMessages from "@/containers/modals/auth/messages";
 import confirmModalMessages from "@/containers/modals/confirm-modal/messages";
 import editPersonalInfoMessages from "@/containers/modals/user-account/messages";
@@ -101,7 +102,8 @@ const messages: MessagesType = {
     ...myWishlistMessages.en,
     ...profileMessages.en,
     ...emailAndPasswordMessages.en,
-    ...confirmModalMessages.en
+    ...confirmModalMessages.en,
+    ...addLinkModalMessages.en
   },
   uk: {
     ...commonMessages.uk,
@@ -151,7 +153,8 @@ const messages: MessagesType = {
     ...myWishlistMessages.uk,
     ...profileMessages.uk,
     ...emailAndPasswordMessages.uk,
-    ...confirmModalMessages.uk
+    ...confirmModalMessages.uk,
+    ...addLinkModalMessages.uk
   }
 };
 

--- a/code/src/store/api/userProfileApi.ts
+++ b/code/src/store/api/userProfileApi.ts
@@ -22,9 +22,20 @@ export const userProfileApi = appApi.injectEndpoints({
         body
       }),
       invalidatesTags: [rtkQueryTags.USER_PROFILE]
+    }),
+    updateUserPhoto: build.mutation<UserResponse, Pick<UserResponse, "photo">>({
+      query: (body) => ({
+        url: URLS.userInfo.photo.put,
+        method: httpMethods.put,
+        body
+      }),
+      invalidatesTags: [rtkQueryTags.USER_PROFILE]
     })
   })
 });
 
-export const { useGetUserInfoQuery, useUpdateUserInfoMutation } =
-  userProfileApi;
+export const {
+  useGetUserInfoQuery,
+  useUpdateUserInfoMutation,
+  useUpdateUserPhotoMutation
+} = userProfileApi;

--- a/code/src/utils/validators/photoScheme.ts
+++ b/code/src/utils/validators/photoScheme.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const AddLinkValidationSchema = z
+  .object({
+    photoURL: z
+      .string()
+      .trim()
+      .min(1, { message: "addLink.error.required" })
+      .url({ message: "addLink.error.invalidUrl" })
+      .refine(
+        (value) => {
+          try {
+            const protocol = new URL(value).protocol;
+            return protocol === "http:" || protocol === "https:";
+          } catch {
+            return false;
+          }
+        },
+        { message: "addLink.error.invalidUrl" }
+      )
+  })
+  .strict();
+
+export type AddLinkValidatorType = z.infer<typeof AddLinkValidationSchema>;


### PR DESCRIPTION
### Description 

Implemented a modal for adding/updating profile img by link

Added:
- Translation (UK/EN)
- Dark/Light theme view
- Validation
- Tests

https://github.com/user-attachments/assets/32c8f50a-1e21-43be-9109-985f8479cee1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Link modal to update your profile photo by pasting an image URL; Save shows loading and closes on success.

* **Validation**
  * Real-time checks: required field, valid URL, and http/https enforcement.

* **Style**
  * Polished modal layout, positioned close control, and aligned action buttons.

* **Localization**
  * English and Ukrainian translations added for the Add Link modal.

* **Tests**
  * Unit tests covering rendering, validation, save/close behavior, and loading state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->