### PR TITLE
[GS3-90] Fixed view history view

### DIFF
--- a/code/src/containers/user-account/view-history/UserViewHistory.module.scss
+++ b/code/src/containers/user-account/view-history/UserViewHistory.module.scss
@@ -8,6 +8,16 @@
   flex-direction: column;
   gap: spacing(10);
 
+  &_products_container {
+    max-width: 1000px;
+    margin: 0 auto;
+  }
+
+  &_products {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+
   &_header {
     display: grid;
     grid-template-columns: 1fr;

--- a/code/src/containers/user-account/view-history/UserViewHistory.module.scss
+++ b/code/src/containers/user-account/view-history/UserViewHistory.module.scss
@@ -15,7 +15,8 @@
 
   &_products {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: spacing(16);
   }
 
   &_header {

--- a/code/src/containers/user-account/view-history/UserViewHistory.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.tsx
@@ -117,11 +117,14 @@ const UserViewHistory = () => {
     }
 
     return (
-      <ProductsContainer
-        products={viewHistoryResponse!.content}
-        isViewHistory
-        wishlist={wishlist}
-      />
+      <AppBox className={styles.viewHistory_products_container}>
+        <ProductsContainer
+          products={viewHistoryResponse!.content}
+          isViewHistory
+          wishlist={wishlist}
+          className={styles.viewHistory_products}
+        />
+      </AppBox>
     );
   };
 

--- a/code/src/containers/user-account/view-history/UserViewHistory.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.tsx
@@ -37,6 +37,7 @@ const UserViewHistory = () => {
   const sortOption = searchParams.get("sort");
   const { renderRedirectComponent } = useErrorPageRedirect();
   const { openModal, closeModal } = useModalContext();
+  const size = 6;
 
   const [deleteAllViewProducts] = useDeleteAllViewProductsMutation();
   const {
@@ -46,7 +47,7 @@ const UserViewHistory = () => {
     error
   } = useGetViewHistoryApiQuery({
     page: page - 1,
-    size: 6,
+    size,
     sort: sortOption ?? undefined,
     lang: locale
   });

--- a/code/src/containers/user-account/view-history/UserViewHistory.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.tsx
@@ -25,18 +25,14 @@ import {
   useGetViewHistoryApiQuery
 } from "@/store/api/viewHistoryApi";
 import { useGetUserWishlistQuery } from "@/store/api/wishlistApi";
-import useScreenSize from "@/utils/check-screen-size/useScreenSize";
 import isErrorWithStatus from "@/utils/is-error-with-status/isErrorWithStatus";
 import repeatComponent from "@/utils/repeat-component/repeatComponent";
-import setProductsPerPageSize from "@/utils/set-product-size/setProductsPerPageSize";
 
 import * as styles from "@/containers/user-account/view-history/UserViewHistory.module.scss";
 
 const UserViewHistory = () => {
   const { page } = usePagination();
-  const screenSize = useScreenSize();
   const { locale } = useLocaleContext();
-  const size = setProductsPerPageSize(screenSize.width);
   const [searchParams, setSearchParams] = useSearchParams();
   const sortOption = searchParams.get("sort");
   const { renderRedirectComponent } = useErrorPageRedirect();
@@ -50,7 +46,7 @@ const UserViewHistory = () => {
     error
   } = useGetViewHistoryApiQuery({
     page: page - 1,
-    size,
+    size: 6,
     sort: sortOption ?? undefined,
     lang: locale
   });


### PR DESCRIPTION
### Description 
Changed the view of the cards on the `View History` page . Now `View History` and `My Wishlist` pages look the same

<img width="1394" height="758" alt="image" src="https://github.com/user-attachments/assets/50663e0f-134a-4dde-ac30-5c2735541600" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated User View History layout: centered content within a constrained width, a responsive grid for viewed products, and a visual container around the products list for cleaner presentation.
* **Behavior**
  * Fixed number of items shown per page (consistent page size rather than varying by screen size).
* **Compatibility**
  * Products list accepts an optional styling hook to support the new layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->