### PR TITLE
[GS-62] Implement My Addresses page

### DIFF
--- a/code/src/components/address-card/AddressCard.module.scss
+++ b/code/src/components/address-card/AddressCard.module.scss
@@ -1,7 +1,7 @@
 @import "@design-system";
 
 .addressCard {
-  width: 350px;
+  width: 325px;
   border: 1px solid var(--color-muted);
   color: var(--color-text);
   display: flex;

--- a/code/src/components/address-card/AddressCard.test.tsx
+++ b/code/src/components/address-card/AddressCard.test.tsx
@@ -58,6 +58,12 @@ describe("AddressCard", () => {
     ).toBeInTheDocument();
   });
 
+  test("renders remove button", () => {
+    renderAndMock();
+
+    expect(screen.getByTestId("remove-address")).toBeInTheDocument();
+  });
+
   test("remove button is disabled when loading", () => {
     renderAndMock({ isLoading: true });
 

--- a/code/src/components/address-card/AddressCard.test.tsx
+++ b/code/src/components/address-card/AddressCard.test.tsx
@@ -1,35 +1,66 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 
-import AddressCard from "./AddressCard";
+import { useUserDetailsSelector } from "@/store/slices/userSlice";
+import { useRemoveUserPermanentAddressMutation } from "@/store/api/addressApi";
+import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
 
-const mockedAddress = [
-  {
-    title: "Home",
-    firstName: "John",
-    lastName: "Doe",
-    phone: "+380960000001",
-    city: "Lviv",
-    postMethod: "NOVA_POSHTA",
-    department: "52"
-  }
-];
+import AddressCard from "@/components/address-card/AddressCard";
+
+jest.mock("@/store/slices/userSlice", () => ({
+  ...jest.requireActual("@/store/slices/userSlice"),
+  useUserDetailsSelector: jest.fn(),
+}));
+
+jest.mock("@/store/api/addressApi", () => ({
+  useRemoveUserPermanentAddressMutation: jest.fn(),
+}));
+
+const mockedAddress = {
+  id: "1",
+  title: "Home",
+  firstName: "John",
+  lastName: "Doe",
+  phone: "+380960000001",
+  city: "Lviv",
+  postMethod: "NOVA_POSHTA",
+  department: "52",
+};
+
+const renderAndMock = ({
+  userId = 4,
+  isLoading = false,
+  removeAddressMock = jest.fn().mockResolvedValue({}),
+} = {}) => {
+  (useUserDetailsSelector as jest.Mock).mockReturnValue(userId ? { id: userId } : null);
+
+  (useRemoveUserPermanentAddressMutation as jest.Mock).mockReturnValue([
+    removeAddressMock,
+    { isLoading },
+  ]);
+
+  return renderWithProviders(<AddressCard address={mockedAddress} />);
+};
 
 describe("AddressCard", () => {
-  it("should render AddressCard correctly", () => {
-    render(<AddressCard address={mockedAddress[0]} />);
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-    const title = screen.getByText(mockedAddress[0].title);
-    const fullName = screen.getByText(
-      `${mockedAddress[0].firstName} ${mockedAddress[0].lastName}`
-    );
-    const phone = screen.getByText(mockedAddress[0].phone);
-    const location = screen.getByText(
-      `${mockedAddress[0].city}, ${mockedAddress[0].postMethod}, ${mockedAddress[0].department}`
-    );
+  test("renders address card correctly", () => {
+    renderAndMock();
+    expect(screen.getByText(mockedAddress.title)).toBeInTheDocument();
+    expect(
+      screen.getByText(`${mockedAddress.firstName} ${mockedAddress.lastName}`)
+    ).toBeInTheDocument();
+    expect(screen.getByText(mockedAddress.phone)).toBeInTheDocument();
+    expect(
+      screen.getByText(`${mockedAddress.city}, ${mockedAddress.postMethod}, ${mockedAddress.department}`)
+    ).toBeInTheDocument();
+  });
 
-    expect(title).toBeInTheDocument();
-    expect(fullName).toBeInTheDocument();
-    expect(phone).toBeInTheDocument();
-    expect(location).toBeInTheDocument();
+  test("remove button is disabled when loading", () => {
+    renderAndMock({ isLoading: true });
+
+    expect(screen.getByTestId("remove-address")).toBeDisabled();
   });
 });

--- a/code/src/components/address-card/AddressCard.tsx
+++ b/code/src/components/address-card/AddressCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import CloseIcon from "@mui/icons-material/Close";
 
 import { AddressCardProps } from "@/components/address-card/AddressCard.types";
@@ -9,6 +8,7 @@ import AppIconButton from "../app-icon-button/AppIconButton";
 
 import { useRemoveUserPermanentAddressMutation } from "@/store/api/addressApi";
 import { useUserDetailsSelector } from "@/store/slices/userSlice";
+import { useModalContext } from "@/context/modal/ModalContext";
 
 import * as styles from "@/components/address-card/AddressCard.module.scss";
 
@@ -19,60 +19,54 @@ const AddressCard = ({ address }: AddressCardProps) => {
   const userId = user?.id;
 
   const [removeAddress, { isLoading }] = useRemoveUserPermanentAddressMutation();
-  const [isModalOpen, setModalOpen] = useState(false);
+  const { openModal, closeModal } = useModalContext();
 
   if (typeof userId !== "number") {
     throw new Error("UserId is required and must be a number");
   }
 
-  const openModal = () => setModalOpen(true);
-  const closeModal = () => setModalOpen(false);
-
-  const handleRemoveConfirmed = async () => {
-    try {
-      await removeAddress({ userId, addressId: id }).unwrap();
-      closeModal();
-    } catch (error) {
-      console.error("Failed to remove address:", error);
-    }
+  const handleRemove = () => {
+    openModal(
+      <ConfirmModal
+        title="addressCard.confirmModal.title"
+        description="addressCard.confirmModal.description"
+        onCancel={closeModal}
+        onSave={async () => {
+          try {
+            await removeAddress({ userId, addressId: id }).unwrap();
+          } catch (error) {
+            console.error("Failed to remove address:", error);
+          }
+        }}
+        textCancel="addressCard.confirmModal.closeButton"
+        textSave="addressCard.confirmModal.saveButton"
+      />
+    );
   };
 
   return (
-    <>
-      <AppBox className={styles.addressCard} data-testid="address-card" data-cy="address-card">
-        <AppBox className={styles.addressCard_header}>
-          <AppTypography variant="subtitle2">{title}</AppTypography>
-          <AppIconButton
-            className={styles.addressCard_header__closeIcon}
-            data-testid="remove-address"
-            disabled={isLoading}
-            onClick={openModal}
-          >
-            <CloseIcon />
-          </AppIconButton>
-        </AppBox>
-        <AppBox className={styles.addressCard_container}>
-          <AppTypography>
-            {firstName} {lastName}
-          </AppTypography>
-          <AppTypography>{phone}</AppTypography>
-          <AppTypography className={styles.addressCard_container__location}>
-            {city}, {postMethod}, {department}
-          </AppTypography>
-        </AppBox>
+    <AppBox className={styles.addressCard} data-testid="address-card" data-cy="address-card">
+      <AppBox className={styles.addressCard_header}>
+        <AppTypography variant="subtitle2">{title}</AppTypography>
+        <AppIconButton
+          className={styles.addressCard_header__closeIcon}
+          data-testid="remove-address"
+          disabled={isLoading}
+          onClick={handleRemove}
+        >
+          <CloseIcon />
+        </AppIconButton>
       </AppBox>
-
-      {isModalOpen && (
-        <ConfirmModal
-          title="addressCard.confirmModal.title"
-          description="addressCard.confirmModal.description"
-          onCancel={closeModal}
-          onSave={handleRemoveConfirmed}
-          textCancel="addressCard.confirmModal.closeButton"
-          textSave="addressCard.confirmModal.saveButton"
-        />
-      )}
-    </>
+      <AppBox className={styles.addressCard_container}>
+        <AppTypography>
+          {firstName} {lastName}
+        </AppTypography>
+        <AppTypography>{phone}</AppTypography>
+        <AppTypography className={styles.addressCard_container__location}>
+          {city}, {postMethod}, {department}
+        </AppTypography>
+      </AppBox>
+    </AppBox>
   );
 };
 

--- a/code/src/components/address-card/AddressCard.tsx
+++ b/code/src/components/address-card/AddressCard.tsx
@@ -13,7 +13,7 @@ const AddressCard = ({ address }: AddressCardProps) => {
     address;
 
   return (
-    <AppBox className={styles.addressCard}>
+    <AppBox className={styles.addressCard} data-testid="address-card" data-cy="address-card">
       <AppBox className={styles.addressCard_header}>
         <AppTypography variant="subtitle2">{title}</AppTypography>
         <AppIconButton

--- a/code/src/components/address-card/AddressCard.tsx
+++ b/code/src/components/address-card/AddressCard.tsx
@@ -1,38 +1,79 @@
+import { useState } from "react";
 import CloseIcon from "@mui/icons-material/Close";
 
 import { AddressCardProps } from "@/components/address-card/AddressCard.types";
 import AppBox from "@/components/app-box/AppBox";
 import AppTypography from "@/components/app-typography/AppTypography";
+import ConfirmModal from "@/containers/modals/confirm-modal/ConfirmModal";
+import AppIconButton from "../app-icon-button/AppIconButton";
+
+import { useRemoveUserPermanentAddressMutation } from "@/store/api/addressApi";
+import { useUserDetailsSelector } from "@/store/slices/userSlice";
 
 import * as styles from "@/components/address-card/AddressCard.module.scss";
 
-import AppIconButton from "../app-icon-button/AppIconButton";
-
 const AddressCard = ({ address }: AddressCardProps) => {
-  const { title, firstName, lastName, phone, city, postMethod, department } =
-    address;
+  const { id, title, firstName, lastName, phone, city, postMethod, department } = address;
+
+  const user = useUserDetailsSelector();
+  const userId = user?.id;
+
+  const [removeAddress, { isLoading }] = useRemoveUserPermanentAddressMutation();
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  if (typeof userId !== "number") {
+    throw new Error("UserId is required and must be a number");
+  }
+
+  const openModal = () => setModalOpen(true);
+  const closeModal = () => setModalOpen(false);
+
+  const handleRemoveConfirmed = async () => {
+    try {
+      await removeAddress({ userId, addressId: id }).unwrap();
+      closeModal();
+    } catch (error) {
+      console.error("Failed to remove address:", error);
+    }
+  };
 
   return (
-    <AppBox className={styles.addressCard} data-testid="address-card" data-cy="address-card">
-      <AppBox className={styles.addressCard_header}>
-        <AppTypography variant="subtitle2">{title}</AppTypography>
-        <AppIconButton
-          className={styles.addressCard_header__closeIcon}
-          data-testid="remove-address"
-        >
-          <CloseIcon />
-        </AppIconButton>
+    <>
+      <AppBox className={styles.addressCard} data-testid="address-card" data-cy="address-card">
+        <AppBox className={styles.addressCard_header}>
+          <AppTypography variant="subtitle2">{title}</AppTypography>
+          <AppIconButton
+            className={styles.addressCard_header__closeIcon}
+            data-testid="remove-address"
+            disabled={isLoading}
+            onClick={openModal}
+          >
+            <CloseIcon />
+          </AppIconButton>
+        </AppBox>
+        <AppBox className={styles.addressCard_container}>
+          <AppTypography>
+            {firstName} {lastName}
+          </AppTypography>
+          <AppTypography>{phone}</AppTypography>
+          <AppTypography className={styles.addressCard_container__location}>
+            {city}, {postMethod}, {department}
+          </AppTypography>
+        </AppBox>
       </AppBox>
-      <AppBox className={styles.addressCard_container}>
-        <AppTypography>
-          {firstName} {lastName}
-        </AppTypography>
-        <AppTypography>{phone}</AppTypography>
-        <AppTypography className={styles.addressCard_container__location}>
-          {city}, {postMethod}, {department}
-        </AppTypography>
-      </AppBox>
-    </AppBox>
+
+      {isModalOpen && (
+        <ConfirmModal
+          title="addressCard.confirmModal.title"
+          description="addressCard.confirmModal.description"
+          onCancel={closeModal}
+          onSave={handleRemoveConfirmed}
+          textCancel="addressCard.confirmModal.closeButton"
+          textSave="addressCard.confirmModal.saveButton"
+        />
+      )}
+    </>
   );
 };
+
 export default AddressCard;

--- a/code/src/components/address-card/AddressCard.tsx
+++ b/code/src/components/address-card/AddressCard.tsx
@@ -32,11 +32,7 @@ const AddressCard = ({ address }: AddressCardProps) => {
         description="addressCard.confirmModal.description"
         onCancel={closeModal}
         onSave={async () => {
-          try {
             await removeAddress({ userId, addressId: id }).unwrap();
-          } catch (error) {
-            console.error("Failed to remove address:", error);
-          }
         }}
         textCancel="addressCard.confirmModal.closeButton"
         textSave="addressCard.confirmModal.saveButton"

--- a/code/src/components/address-card/AddressCard.types.ts
+++ b/code/src/components/address-card/AddressCard.types.ts
@@ -1,5 +1,6 @@
 export type AddressCardProps = {
   address: {
+    id: string;
     title: string;
     firstName: string;
     lastName: string;

--- a/code/src/components/address-card/messages/en.json
+++ b/code/src/components/address-card/messages/en.json
@@ -1,0 +1,6 @@
+{
+  "addressCard.confirmModal.title": "Delete address?",
+  "addressCard.confirmModal.description": "Are you sure you want to delete this address? This action cannot be undone.",
+  "addressCard.confirmModal.closeButton": "Cancel",
+  "addressCard.confirmModal.saveButton": "Delete"
+}

--- a/code/src/components/address-card/messages/index.ts
+++ b/code/src/components/address-card/messages/index.ts
@@ -1,0 +1,4 @@
+import en from "@/components/address-card/messages/en.json";
+import uk from "@/components/address-card/messages/uk.json";
+
+export default { en, uk };

--- a/code/src/components/address-card/messages/uk.json
+++ b/code/src/components/address-card/messages/uk.json
@@ -1,0 +1,6 @@
+{
+  "addressCard.confirmModal.title": "Видалити адресу?",
+  "addressCard.confirmModal.description": "Ви впевнені, що хочете видалити цю адресу? Цю операцію не можна буде скасувати.",
+  "addressCard.confirmModal.closeButton": "Відміна",
+  "addressCard.confirmModal.saveButton": "Видалити"
+}

--- a/code/src/constants/api-tags.ts
+++ b/code/src/constants/api-tags.ts
@@ -10,7 +10,8 @@ export const rtkQueryTags = {
   SUGGESTED_PRODUCT: "SUGGESTED_PRODUCT",
   USER_PROFILE: "USER_PROFILE",
   VIEW_HISTORY: "VIEW_HISTORY",
-  WISHLIST: "WISHLIST"
+  WISHLIST: "WISHLIST",
+  ADDRESSES: "ADDRESSES",
 } as const;
 
 export const rtkQueryTagsArray = Object.values(rtkQueryTags);

--- a/code/src/constants/requests.ts
+++ b/code/src/constants/requests.ts
@@ -18,6 +18,7 @@ import {
   GetUserProductsBySearchQueryParams,
   UpdateProductBody
 } from "@/types/product.types";
+import { AddressesGetParams } from "@/types/address.types";
 import { GetUsersForAdminParams } from "@/types/user.types";
 import createUrlPath from "@/utils/create-url-path/createUrlPath";
 
@@ -110,5 +111,8 @@ export const URLS = {
       `/v1/my-wishlist/${productId}`,
     delete: ({ productId }: { productId: string }) =>
       `/v1/my-wishlist/${productId}`
+  },
+  address: {
+    get: ({userId}: AddressesGetParams) => `/v1/users/${userId}/addresses`
   }
 } as const;

--- a/code/src/constants/requests.ts
+++ b/code/src/constants/requests.ts
@@ -18,7 +18,10 @@ import {
   GetUserProductsBySearchQueryParams,
   UpdateProductBody
 } from "@/types/product.types";
-import { AddressesGetParams } from "@/types/address.types";
+import {
+  AddressesGetParams,
+  AddressesDeleteParams
+} from "@/types/address.types";
 import { GetUsersForAdminParams } from "@/types/user.types";
 import createUrlPath from "@/utils/create-url-path/createUrlPath";
 
@@ -113,6 +116,8 @@ export const URLS = {
       `/v1/my-wishlist/${productId}`
   },
   address: {
-    get: ({userId}: AddressesGetParams) => `/v1/users/${userId}/addresses`
+    get: ({userId}: AddressesGetParams) => `/v1/users/${userId}/addresses`,
+    delete: ({ userId, addressId }: AddressesDeleteParams) =>
+      `/v1/users/${userId}/addresses/${addressId}`
   }
 } as const;

--- a/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
@@ -9,6 +9,7 @@
     padding: spacing(10);
     max-width: 100%;
     box-sizing: border-box;
+    padding-bottom: 420px;
 
     &_header {
         display: grid;

--- a/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
@@ -10,7 +10,7 @@
     padding: spacing(10);
     max-width: 100%;
     box-sizing: border-box;
-    padding-bottom: 420px;
+    min-height: 420px;
 
     &_header {
         display: grid;
@@ -25,13 +25,6 @@
         }
     }
 
-    &_emptyMessage {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        padding: 210px 0;
-    }
-
     &_error {
         display: flex;
         align-items: center;
@@ -43,6 +36,17 @@
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
         gap: spacing(10);
+        position: relative;
+    }
+
+    &_emptyMessage {
+        position: absolute;
+        transform: translate(-50%, -50%);
+        top: 50%;
+        left: 50%;
+        display: flex;
+        justify-content: center;
+        padding-top: 200px;
     }
 
     &_loader {

--- a/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
@@ -22,4 +22,31 @@
         align-items: center;
         }
     }
+
+    &_emptyMessage {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 210px 0;
+    }
+
+    &_error {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: spacing(10);
+    }
+
+    &_list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: spacing(10);
+    }
+
+      &_loader {
+        transform: translate(-50%, -50%);
+        position: absolute;
+        top: 50%;
+        left: 50%;
+    }
 }

--- a/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
@@ -10,7 +10,7 @@
     padding: spacing(10);
     max-width: 100%;
     box-sizing: border-box;
-    min-height: 420px;
+    min-height: 620px;
 
     &_header {
         display: grid;
@@ -46,7 +46,7 @@
         left: 50%;
         display: flex;
         justify-content: center;
-        padding-top: 200px;
+        padding-top: 320px;
     }
 
     &_loader {

--- a/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
@@ -11,15 +11,15 @@
     box-sizing: border-box;
 
     &_header {
-    display: grid;
-    grid-template-columns: 1fr;
-    row-gap: 2rem;
-    justify-items: center;
+        display: grid;
+        grid-template-columns: 1fr;
+        row-gap: 2rem;
+        justify-items: center;
 
         @include breakpoint("sm") {
-        grid-template-columns: 1fr 1fr;
-        justify-items: stretch;
-        align-items: center;
+            grid-template-columns: 1fr 1fr;
+            justify-items: stretch;
+            align-items: center;
         }
     }
 
@@ -43,7 +43,7 @@
         gap: spacing(10);
     }
 
-      &_loader {
+    &_loader {
         transform: translate(-50%, -50%);
         position: absolute;
         top: 50%;

--- a/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
@@ -1,0 +1,24 @@
+@import "@design-system";
+
+.MyAddresses {
+    padding: spacing(10);
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    display: flex;
+    flex-direction: column;
+    gap: spacing(10);
+    width: 100%;
+
+    &_header {
+    display: grid;
+    grid-template-columns: 1fr;
+    row-gap: 2rem;
+    justify-items: center;
+
+        @include breakpoint("sm") {
+        grid-template-columns: 1fr 1fr;
+        justify-items: stretch;
+        align-items: center;
+        }
+    }
+}

--- a/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
@@ -1,6 +1,7 @@
 @import "@design-system";
 
 .MyAddresses {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: spacing(10);

--- a/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.module.scss
@@ -1,13 +1,14 @@
 @import "@design-system";
 
 .MyAddresses {
-    padding: spacing(10);
-    background-color: var(--color-surface);
-    color: var(--color-text);
     display: flex;
     flex-direction: column;
     gap: spacing(10);
-    width: 100%;
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    padding: spacing(10);
+    max-width: 100%;
+    box-sizing: border-box;
 
     &_header {
     display: grid;

--- a/code/src/containers/user-account/my-addresses/MyAddresses.test.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.test.tsx
@@ -1,0 +1,112 @@
+import { screen } from "@testing-library/react";
+
+import MyAddresses from "@/containers/user-account/my-addresses/MyAddresses";
+
+import { useUserDetailsSelector } from "@/store/slices/userSlice";
+import { useGetUserAddressesQuery } from "@/store/api/addressApi";
+
+import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
+
+
+jest.mock("@/store/slices/userSlice", () => ({
+  ...jest.requireActual("@/store/slices/userSlice"),
+  useUserDetailsSelector: jest.fn()
+}));
+
+jest.mock("@/store/api/addressApi", () => ({
+  useGetUserAddressesQuery: jest.fn()
+}));
+
+const mockAddresses = [
+  {
+    id: "1",
+    deliveryMethod: "Nova Poshta",
+    city: "Lviv",
+    department: "52",
+    title: "Home",
+    firstName: "John",
+    lastName: "Doe",
+    phone: "+380960775434"
+  },
+  {
+    id: "2",
+    deliveryMethod: "Ukrposhta",
+    city: "Kyiv",
+    department: "14",
+    title: "Office",
+    firstName: "Jane",
+    lastName: "Smith",
+    phone: "+380970123456"
+  }
+];
+
+const renderAndMock = ({
+  addresses = mockAddresses,
+  isLoading = false,
+  isError = false,
+  userId = 4
+}: {
+  addresses?: typeof mockAddresses;
+  isLoading?: boolean;
+  isError?: boolean;
+  userId?: number | null;
+}) => {
+  (useUserDetailsSelector as jest.Mock).mockReturnValue(userId ? { id: userId } : null);
+
+  (useGetUserAddressesQuery as jest.Mock).mockReturnValue({
+    data: addresses,
+    isLoading,
+    isError
+  });
+
+  return renderWithProviders(<MyAddresses />);
+};
+
+describe("MyAddresses", () => {
+  test("renders loader when loading", () => {
+    renderAndMock({ isLoading: true });
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  test("renders empty message when no addresses", () => {
+    renderAndMock({ addresses: [] });
+    expect(screen.getByText(/myAddresses.emptyMessage/i)).toBeInTheDocument();
+  });
+
+  test("renders error message when request fails", () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    renderAndMock({ isError: true });
+
+    expect(screen.getByText(/myAddresses.error.label/i)).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("renders address cards when addresses are present", () => {
+    renderAndMock({});
+    expect(screen.getAllByTestId("address-card")).toHaveLength(mockAddresses.length);
+  });
+
+  test("throws error if userId is invalid", () => {
+    const consoleErrorSpy = jest
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+    expect(() => {
+        renderAndMock({ userId: null });
+        }).toThrow("UserId is required and must be a number");
+
+        consoleErrorSpy.mockRestore();
+  });
+
+  test("calls useGetUserAddressesQuery with correct userId", () => {
+        const mockUserId = 42;
+        (useUserDetailsSelector as jest.Mock).mockReturnValue({ id: mockUserId });
+
+        renderWithProviders(<MyAddresses />);
+
+        expect(useGetUserAddressesQuery).toHaveBeenCalledWith({ userId: mockUserId });
+    });
+});

--- a/code/src/containers/user-account/my-addresses/MyAddresses.test.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.test.tsx
@@ -72,17 +72,6 @@ describe("MyAddresses", () => {
     expect(screen.getByText(/myAddresses.emptyMessage/i)).toBeInTheDocument();
   });
 
-  test("renders error message when request fails", () => {
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-
-    renderAndMock({ isError: true });
-
-    expect(screen.getByText(/myAddresses.error.label/i)).toBeInTheDocument();
-    expect(consoleErrorSpy).toHaveBeenCalled();
-
-    consoleErrorSpy.mockRestore();
-  });
-
   test("renders address cards when addresses are present", () => {
     renderAndMock({});
     expect(screen.getAllByTestId("address-card")).toHaveLength(mockAddresses.length);

--- a/code/src/containers/user-account/my-addresses/MyAddresses.test.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.test.tsx
@@ -12,7 +12,8 @@ jest.mock("@/store/slices/userSlice", () => ({
 }));
 
 jest.mock("@/store/api/addressApi", () => ({
-  useGetUserAddressesQuery: jest.fn()
+  useGetUserAddressesQuery: jest.fn(),
+  useRemoveUserPermanentAddressMutation: jest.fn(() => [jest.fn(), { isLoading: false }])
 }));
 
 const mockAddresses = [

--- a/code/src/containers/user-account/my-addresses/MyAddresses.test.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.test.tsx
@@ -4,9 +4,7 @@ import MyAddresses from "@/containers/user-account/my-addresses/MyAddresses";
 
 import { useUserDetailsSelector } from "@/store/slices/userSlice";
 import { useGetUserAddressesQuery } from "@/store/api/addressApi";
-
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
-
 
 jest.mock("@/store/slices/userSlice", () => ({
   ...jest.requireActual("@/store/slices/userSlice"),
@@ -96,9 +94,9 @@ describe("MyAddresses", () => {
 
     expect(() => {
         renderAndMock({ userId: null });
-        }).toThrow("UserId is required and must be a number");
+    }).toThrow("UserId is required and must be a number");
 
-        consoleErrorSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 
   test("calls useGetUserAddressesQuery with correct userId", () => {

--- a/code/src/containers/user-account/my-addresses/MyAddresses.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.tsx
@@ -1,25 +1,70 @@
 import AppBox from "@/components/app-box/AppBox";
 import AppContainer from "@/components/app-container/AppContainer";
-//import AppLoader from "@/components/app-loader/AppLoader";
+import AppLoader from "@/components/app-loader/AppLoader";
 import AppTypography from "@/components/app-typography/AppTypography";
+import AddressCard from "@/components/address-card/AddressCard";
+
+import { useGetUserAddressesQuery } from "@/store/api/addressApi";
 
 import * as styles from "@/containers/user-account/my-addresses/MyAddresses.module.scss";
+import { useUserDetailsSelector } from "@/store/slices/userSlice";
 
-const MyAddresses = () => {
-    // if (isLoading) {
-    //     return <AppLoader size="extra-large" className={styles.Profile__loader} />;
-    // }
+const MyAddresses = () => {    
+    const user = useUserDetailsSelector();
+    const userId = user?.id; 
 
-    //if (!user) return null;
+    if (typeof userId !== "number") {
+        throw new Error("UserId is required and must be a number");
+    }
+    
+    const { data: addresses, isLoading, isError } = useGetUserAddressesQuery({ userId });
+    
+    if (isLoading) {
+        return <AppLoader size="extra-large" className={styles.MyAddresses_loader} />;
+    }
+
+    const isEmpty = !isLoading && addresses?.length === 0;
+
+    if (isEmpty) {
+        return (
+            <AppContainer className={styles.MyAddresses_emptyMessage}>
+                <AppTypography variant="body" translationKey="myAddresses.emptyMessage" />
+            </AppContainer>
+        );
+    }
+
+    if (isError) {
+        console.error("Error fetching user addresses:", isError);
+        return (
+            <AppBox className={styles.MyAddresses_error} data-cy="my-addresses-error">
+                <AppTypography
+                    variant="subtitle2"
+                    fontWeight="semi-bold"
+                    translationKey="myAddresses.error.label"
+                    data-cy="my-addresses-error-label"
+                />
+            </AppBox>
+        );
+    }
 
     return (
         <AppContainer className={styles.MyAddresses}>
             <AppBox className={styles.MyAddresses_header}>
                 <AppTypography variant="h3" translationKey="myAddresses.title" />
             </AppBox>
+            <AppBox className={styles.MyAddresses_list}>
+                {(addresses ?? []).map((addr) => (
+                    <AddressCard
+                        key={addr.id}
+                        address={{
+                            ...addr,
+                            postMethod: addr.deliveryMethod ?? "",
+                        }}
+                    />
+                ))}
+            </AppBox>
         </AppContainer>
     );
 };
 
 export default MyAddresses;
-

--- a/code/src/containers/user-account/my-addresses/MyAddresses.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.tsx
@@ -18,25 +18,35 @@ const MyAddresses = () => {
     }
     
     const { data: addresses, isLoading, isError } = useGetUserAddressesQuery({ userId });
-
     const isEmpty = !isLoading && addresses?.length === 0;
-    
-    if (isLoading) {
-        return <AppLoader size="extra-large" className={styles.MyAddresses_loader} />;
-    }
 
-    if (isError) {
-        console.error("Error fetching user addresses:", isError);
-        return (
-            <AppBox className={styles.MyAddresses_error} data-cy="my-addresses-error">
-                <AppTypography
-                    variant="subtitle2"
-                    fontWeight="semi-bold"
-                    translationKey="myAddresses.error.label"
-                    data-cy="my-addresses-error-label"
-                />
-            </AppBox>
-        );
+    const content = () => {
+        if (isEmpty) {
+            return (
+                <AppContainer className={styles.MyAddresses_emptyMessage}>
+                    <AppTypography variant="body" translationKey="myAddresses.emptyMessage" />
+                </AppContainer>
+            )
+        };
+    
+        if (isLoading) {
+            return <AppLoader size="extra-large" className={styles.MyAddresses_loader} />;
+        };
+
+        if (isError) {
+            return (
+                <AppBox className={styles.MyAddresses_error} data-cy="my-addresses-error">
+                    <AppTypography
+                        variant="subtitle2"
+                        fontWeight="semi-bold"
+                        translationKey="myAddresses.error.label"
+                        data-cy="my-addresses-error-label"
+                    />
+                </AppBox>
+            );
+        }
+
+        return null;
     }
 
     return (
@@ -55,11 +65,7 @@ const MyAddresses = () => {
                     />
                 ))}
             </AppBox>
-            {isEmpty && (
-                <AppContainer className={styles.MyAddresses_emptyMessage}>
-                    <AppTypography variant="body" translationKey="myAddresses.emptyMessage" />
-                </AppContainer>
-            )}
+            {content()}
         </AppContainer>
     );
 };

--- a/code/src/containers/user-account/my-addresses/MyAddresses.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.tsx
@@ -1,0 +1,25 @@
+import AppBox from "@/components/app-box/AppBox";
+import AppContainer from "@/components/app-container/AppContainer";
+//import AppLoader from "@/components/app-loader/AppLoader";
+import AppTypography from "@/components/app-typography/AppTypography";
+
+import * as styles from "@/containers/user-account/my-addresses/MyAddresses.module.scss";
+
+const MyAddresses = () => {
+    // if (isLoading) {
+    //     return <AppLoader size="extra-large" className={styles.Profile__loader} />;
+    // }
+
+    //if (!user) return null;
+
+    return (
+        <AppContainer className={styles.MyAddresses}>
+            <AppBox className={styles.MyAddresses_header}>
+                <AppTypography variant="h3" translationKey="myAddresses.title" />
+            </AppBox>
+        </AppContainer>
+    );
+};
+
+export default MyAddresses;
+

--- a/code/src/containers/user-account/my-addresses/MyAddresses.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.tsx
@@ -9,26 +9,17 @@ import { useUserDetailsSelector } from "@/store/slices/userSlice";
 
 import * as styles from "@/containers/user-account/my-addresses/MyAddresses.module.scss";
 
-const MyAddresses = () => {    
+const MyAddresses = () => {
     const user = useUserDetailsSelector();
-    const userId = user?.id; 
+    const userId = user?.id;
 
     if (typeof userId !== "number") {
         throw new Error("UserId is required and must be a number");
     }
-    
+
     const { data: addresses, isLoading, isError } = useGetUserAddressesQuery({ userId });
-    const isEmpty = !isLoading && addresses?.length === 0;
 
     const content = () => {
-        if (isEmpty) {
-            return (
-                <AppContainer className={styles.MyAddresses_emptyMessage}>
-                    <AppTypography variant="body" translationKey="myAddresses.emptyMessage" />
-                </AppContainer>
-            )
-        };
-    
         if (isLoading) {
             return <AppLoader size="extra-large" className={styles.MyAddresses_loader} />;
         };
@@ -46,24 +37,32 @@ const MyAddresses = () => {
             );
         }
 
-        return null;
+        return (
+            <AppBox className={styles.MyAddresses_list}>
+                {addresses?.length === 0 ? (
+                    <AppContainer className={styles.MyAddresses_emptyMessage}>
+                        <AppTypography variant="body" translationKey="myAddresses.emptyMessage" />
+                    </AppContainer>
+                ) : (
+                    (addresses ?? []).map((addr) => (
+                        <AddressCard
+                            key={addr.id}
+                            address={{
+                                ...addr,
+                                postMethod: addr.deliveryMethod,
+                            }}
+                        />
+                    ))
+                )
+                }
+            </AppBox>
+        );
     }
 
     return (
         <AppContainer className={styles.MyAddresses}>
             <AppBox className={styles.MyAddresses_header}>
                 <AppTypography variant="h3" translationKey="myAddresses.title" />
-            </AppBox>
-            <AppBox className={styles.MyAddresses_list}>
-                {(addresses ?? []).map((addr) => (
-                    <AddressCard
-                        key={addr.id}
-                        address={{
-                            ...addr,
-                            postMethod: addr.deliveryMethod,
-                        }}
-                    />
-                ))}
             </AppBox>
             {content()}
         </AppContainer>

--- a/code/src/containers/user-account/my-addresses/MyAddresses.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.tsx
@@ -5,9 +5,9 @@ import AppTypography from "@/components/app-typography/AppTypography";
 import AddressCard from "@/components/address-card/AddressCard";
 
 import { useGetUserAddressesQuery } from "@/store/api/addressApi";
+import { useUserDetailsSelector } from "@/store/slices/userSlice";
 
 import * as styles from "@/containers/user-account/my-addresses/MyAddresses.module.scss";
-import { useUserDetailsSelector } from "@/store/slices/userSlice";
 
 const MyAddresses = () => {    
     const user = useUserDetailsSelector();

--- a/code/src/containers/user-account/my-addresses/MyAddresses.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.tsx
@@ -18,19 +18,11 @@ const MyAddresses = () => {
     }
     
     const { data: addresses, isLoading, isError } = useGetUserAddressesQuery({ userId });
+
+    const isEmpty = !isLoading && addresses?.length === 0;
     
     if (isLoading) {
         return <AppLoader size="extra-large" className={styles.MyAddresses_loader} />;
-    }
-
-    const isEmpty = !isLoading && addresses?.length === 0;
-
-    if (isEmpty) {
-        return (
-            <AppContainer className={styles.MyAddresses_emptyMessage}>
-                <AppTypography variant="body" translationKey="myAddresses.emptyMessage" />
-            </AppContainer>
-        );
     }
 
     if (isError) {
@@ -63,6 +55,11 @@ const MyAddresses = () => {
                     />
                 ))}
             </AppBox>
+            {isEmpty && (
+                <AppContainer className={styles.MyAddresses_emptyMessage}>
+                    <AppTypography variant="body" translationKey="myAddresses.emptyMessage" />
+                </AppContainer>
+            )}
         </AppContainer>
     );
 };

--- a/code/src/containers/user-account/my-addresses/MyAddresses.tsx
+++ b/code/src/containers/user-account/my-addresses/MyAddresses.tsx
@@ -50,7 +50,7 @@ const MyAddresses = () => {
                         key={addr.id}
                         address={{
                             ...addr,
-                            postMethod: addr.deliveryMethod ?? "",
+                            postMethod: addr.deliveryMethod,
                         }}
                     />
                 ))}

--- a/code/src/containers/user-account/my-addresses/messages/en.json
+++ b/code/src/containers/user-account/my-addresses/messages/en.json
@@ -1,0 +1,4 @@
+{
+    "myAddresses.title": "My Addresses",
+    "myAddresses.emptyMessage": "You haven't added any addresses yet."
+}

--- a/code/src/containers/user-account/my-addresses/messages/en.json
+++ b/code/src/containers/user-account/my-addresses/messages/en.json
@@ -1,4 +1,5 @@
 {
     "myAddresses.title": "My Addresses",
-    "myAddresses.emptyMessage": "You haven't added any addresses yet."
+    "myAddresses.emptyMessage": "You haven't added any addresses yet.",
+    "myAddresses.error.label": "Something went wrong. Please try again later."
 }

--- a/code/src/containers/user-account/my-addresses/messages/index.ts
+++ b/code/src/containers/user-account/my-addresses/messages/index.ts
@@ -1,0 +1,4 @@
+import en from "@/containers/user-account/my-addresses/messages/en.json";
+import uk from "@/containers/user-account/my-addresses/messages/uk.json";
+
+export default { en, uk };

--- a/code/src/containers/user-account/my-addresses/messages/uk.json
+++ b/code/src/containers/user-account/my-addresses/messages/uk.json
@@ -1,4 +1,5 @@
 {
     "myAddresses.title": "Мої адреси",
-    "myAddresses.emptyMessage": "Ви ще не додали жодної адреси."
+    "myAddresses.emptyMessage": "Ви ще не додали жодної адреси.",
+    "myAddresses.error.label": "Щось пішло не так. Будь ласка, спробуйте ще раз пізніше."
 }

--- a/code/src/containers/user-account/my-addresses/messages/uk.json
+++ b/code/src/containers/user-account/my-addresses/messages/uk.json
@@ -1,0 +1,4 @@
+{
+    "myAddresses.title": "Мої адреси",
+    "myAddresses.emptyMessage": "Ви ще не додали жодної адреси."
+}

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.module.scss
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.module.scss
@@ -22,7 +22,6 @@
     justify-content: space-between;
     align-items: center;
     margin-top: spacing(5);
-    // width: 100%;
   }
 
   &_count,

--- a/code/src/containers/user-account/my-wishlist/MyWishlist.module.scss
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.module.scss
@@ -7,6 +7,8 @@
   gap: spacing(10);
   display: flex;
   flex-direction: column;
+  max-width: 100%;
+  box-sizing: border-box;
 
   &_emptyMessage {
     display: flex;
@@ -20,7 +22,7 @@
     justify-content: space-between;
     align-items: center;
     margin-top: spacing(5);
-    width: 100%;
+    // width: 100%;
   }
 
   &_count,
@@ -44,13 +46,9 @@
   &_productsGrid {
     margin-top: spacing(4);
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     justify-content: flex-start;
     width: 100%;
-    gap: spacing(16);
-
-    & > * {
-      width: 280px;
-    }
+    gap: spacing(5);
   }
 }

--- a/code/src/containers/user-account/profile/Profile.module.scss
+++ b/code/src/containers/user-account/profile/Profile.module.scss
@@ -7,6 +7,8 @@
   background-color: var(--color-surface);
   color: var(--color-text);
   padding: spacing(10);
+  max-width: 100%;
+  box-sizing: border-box;
 
   &__divider {
     border: 1px solid $light;

--- a/code/src/containers/user-account/view-history/UserViewHistory.module.scss
+++ b/code/src/containers/user-account/view-history/UserViewHistory.module.scss
@@ -56,13 +56,4 @@
     grid-template-rows: repeat(2, auto);
     gap: 1rem;
   }
-
-  &_productsGrid {
-    margin-top: spacing(4);
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    justify-content: flex-start;
-    width: 100%;
-    gap: spacing(5);
-  }
 }

--- a/code/src/containers/user-account/view-history/UserViewHistory.module.scss
+++ b/code/src/containers/user-account/view-history/UserViewHistory.module.scss
@@ -56,4 +56,13 @@
     grid-template-rows: repeat(2, auto);
     gap: 1rem;
   }
+
+  &_productsGrid {
+    margin-top: spacing(4);
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    justify-content: flex-start;
+    width: 100%;
+    gap: spacing(5);
+  }
 }

--- a/code/src/containers/user-account/view-history/UserViewHistory.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.tsx
@@ -115,7 +115,6 @@ const UserViewHistory = () => {
 
     return (
       <ProductsContainer
-        className={styles.viewHistory_productsGrid}
         products={viewHistoryResponse!.content}
         isViewHistory
         wishlist={wishlist}

--- a/code/src/containers/user-account/view-history/UserViewHistory.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.tsx
@@ -115,6 +115,7 @@ const UserViewHistory = () => {
 
     return (
       <ProductsContainer
+        className={styles.viewHistory_productsGrid}
         products={viewHistoryResponse!.content}
         isViewHistory
         wishlist={wishlist}

--- a/code/src/messages.ts
+++ b/code/src/messages.ts
@@ -25,6 +25,7 @@ import usersTableMessages from "@/containers/tables/users-table/messages";
 import myWishlistMessages from "@/containers/user-account/my-wishlist/messages";
 import profileMessages from "@/containers/user-account/profile/messages";
 import userViewHistoryMessages from "@/containers/user-account/view-history/messages";
+import myAddressesMessages from "@/containers/user-account/my-addresses/messages";
 
 import dropDownMessages from "@/components/app-dropdown/messages";
 import bestSellerContainerMessages from "@/components/bestseller-card/messages";
@@ -103,7 +104,8 @@ const messages: MessagesType = {
     ...profileMessages.en,
     ...emailAndPasswordMessages.en,
     ...confirmModalMessages.en,
-    ...addLinkModalMessages.en
+    ...addLinkModalMessages.en,
+    ...myAddressesMessages.en
   },
   uk: {
     ...commonMessages.uk,
@@ -154,7 +156,8 @@ const messages: MessagesType = {
     ...profileMessages.uk,
     ...emailAndPasswordMessages.uk,
     ...confirmModalMessages.uk,
-    ...addLinkModalMessages.uk
+    ...addLinkModalMessages.uk,
+    ...myAddressesMessages.uk
   }
 };
 

--- a/code/src/messages.ts
+++ b/code/src/messages.ts
@@ -33,6 +33,7 @@ import productCardMessages from "@/components/product-card/messages";
 import emailAndPasswordMessages from "@/components/profile-email-password/messages";
 import PersonalInformation from "@/components/profile-personal-information/messages";
 import sidebar from "@/components/sidebar/messages";
+import AddressCardMessages from "@/components/address-card/messages"
 
 import commonMessages from "@/constants/common-messages";
 import { Locale } from "@/context/i18n/I18nProvider";
@@ -105,7 +106,8 @@ const messages: MessagesType = {
     ...emailAndPasswordMessages.en,
     ...confirmModalMessages.en,
     ...addLinkModalMessages.en,
-    ...myAddressesMessages.en
+    ...myAddressesMessages.en,
+    ...AddressCardMessages.en
   },
   uk: {
     ...commonMessages.uk,
@@ -157,7 +159,8 @@ const messages: MessagesType = {
     ...emailAndPasswordMessages.uk,
     ...confirmModalMessages.uk,
     ...addLinkModalMessages.uk,
-    ...myAddressesMessages.uk
+    ...myAddressesMessages.uk,
+    ...AddressCardMessages.uk
   }
 };
 

--- a/code/src/pages/user-account/Addresses/AddressesPage.tsx
+++ b/code/src/pages/user-account/Addresses/AddressesPage.tsx
@@ -1,5 +1,0 @@
-const AddressesPage = () => {
-  return <h1>Adresses page</h1>;
-};
-
-export default AddressesPage;

--- a/code/src/pages/user-account/Profile/ProfilePage.tsx
+++ b/code/src/pages/user-account/Profile/ProfilePage.tsx
@@ -1,5 +1,0 @@
-const ProfilePage = () => {
-  return <h1>Profile page</h1>;
-};
-
-export default ProfilePage;

--- a/code/src/routes/protectedRoutes.tsx
+++ b/code/src/routes/protectedRoutes.tsx
@@ -48,8 +48,8 @@ const Profile = lazy(
 const MyWishlist = lazy(
   () => import("@/containers/user-account/my-wishlist/MyWishlist")
 );
-const AddressesPage = lazy(
-  () => import("@/pages/user-account/Addresses/AddressesPage")
+const MyAddresses = lazy(
+  () => import("@/containers/user-account/my-addresses/MyAddresses")
 );
 
 const protectedRoutes: RouteObject[] = [
@@ -134,7 +134,7 @@ const protectedRoutes: RouteObject[] = [
       },
       {
         path: routePaths.userCabinet.addresses.path,
-        element: <AddressesPage />
+        element: <MyAddresses />
       }
     ]
   }

--- a/code/src/store/api/addressApi.ts
+++ b/code/src/store/api/addressApi.ts
@@ -5,6 +5,7 @@ import { rtkQueryTags } from "@/constants/api-tags";
 
 import { 
     AddressesGetParams,
+    AddressesDeleteParams,
     UserAddressResponse
 } from "@/types/address.types";
 
@@ -17,7 +18,17 @@ export const addressApi = appApi.injectEndpoints({
       }),
       providesTags: [rtkQueryTags.ADDRESSES],
     }),
+    removeUserPermanentAddress: build.mutation<void, AddressesDeleteParams>({
+      query: (params) => ({
+        url: URLS.address.delete(params),
+        method: httpMethods.delete
+      }),
+      invalidatesTags: [rtkQueryTags.ADDRESSES]
+    })
   }),
 });
 
-export const { useGetUserAddressesQuery } = addressApi;
+export const {
+  useGetUserAddressesQuery,
+  useRemoveUserPermanentAddressMutation
+} = addressApi;

--- a/code/src/store/api/addressApi.ts
+++ b/code/src/store/api/addressApi.ts
@@ -1,0 +1,23 @@
+import { appApi } from "@/store/api/appApi";
+import { URLS } from "@/constants/requests";
+import { httpMethods } from "@/constants/methods";
+import { rtkQueryTags } from "@/constants/api-tags";
+
+import { 
+    AddressesGetParams,
+    UserAddressResponse
+} from "@/types/address.types";
+
+export const addressApi = appApi.injectEndpoints({
+  endpoints: (build) => ({
+    getUserAddresses: build.query<UserAddressResponse[], AddressesGetParams>({
+      query: (params) => ({
+          url: URLS.address.get(params),
+          method: httpMethods.get
+      }),
+      providesTags: [rtkQueryTags.ADDRESSES],
+    }),
+  }),
+});
+
+export const { useGetUserAddressesQuery } = addressApi;

--- a/code/src/types/address.types.ts
+++ b/code/src/types/address.types.ts
@@ -1,8 +1,13 @@
 import { UserId } from "@/types/user.types";
 
 export type AddressesGetParams = {
+    userId: UserId
+};
+
+export type AddressesDeleteParams = {
     userId: UserId;
-}
+    addressId: string
+};
 
 export type UserAddressResponse = {
   id: string;

--- a/code/src/types/address.types.ts
+++ b/code/src/types/address.types.ts
@@ -1,0 +1,16 @@
+import { UserId } from "@/types/user.types";
+
+export type AddressesGetParams = {
+    userId: UserId;
+}
+
+export type UserAddressResponse = {
+  id: string;
+  deliveryMethod: string;
+  city: string;
+  department: string;
+  title: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+}


### PR DESCRIPTION
* Added `My Addresses` page with relevant styles, according to the figma mockups;
<img width="1796" height="711" alt="image" src="https://github.com/user-attachments/assets/7306c83d-451f-43f2-9ad3-e66a8677895d" />

* Added confirmation modal in Address Card fro deleting the address

<img width="1824" height="697" alt="image" src="https://github.com/user-attachments/assets/753e1936-767b-4279-8720-c9c410b006fd" />

* Added tests for `My Addresses` and run stryker:
<img width="927" height="108" alt="image" src="https://github.com/user-attachments/assets/9d433b15-9e60-4a65-8237-028d111b07b1" />

* Added API Endpoints for User Addresses:
**GET** /v1/users/{userId}/addresses — fetch user addresses list
**DELETE** /v1/users/{userId}/addresses/{addressId} — remove a specific user address

<img width="1892" height="608" alt="image" src="https://github.com/user-attachments/assets/07eedd49-495a-449e-ad29-22061d884a15" />

<img width="1877" height="620" alt="image" src="https://github.com/user-attachments/assets/ce691aa1-98ac-41bd-a70d-701f43ff15f1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - My Addresses page to view saved addresses and remove them via a confirmation modal; delete action is disabled while processing.

- **Localization**
  - English and Ukrainian translations added for the My Addresses UI and delete confirmation modal.

- **Style**
  - Slightly narrower address cards and layout refinements for account pages to improve responsiveness.

- **Tests**
  - Unit tests added for My Addresses and Address Card render, loading, error, and removal scenarios.

- **Chores**
  - Routes updated to use the new My Addresses experience and address management integrated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->