### PR TITLE
[GS3-97] Updated endpoint in header

### DIFF
--- a/code/src/constants/requests.ts
+++ b/code/src/constants/requests.ts
@@ -97,6 +97,7 @@ export const URLS = {
     getUserInfo: "/v2/my-info",
     patchUserInfo: "/v2/my-info",
     photo: {
+      get: "/v1/my-info/photo",
       put: "/v1/my-info/photo",
       delete: "/v1/my-info/photo"
     }

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
@@ -7,8 +7,6 @@ import HeaderAccountButton from "@/layouts/header/components/header-buttons/head
 import { AppMenuProps, MenuItem } from "@/components/app-menu/AppMenu.types";
 
 import { useGetUserPhotoQuery } from "@/store/api/userProfileApi";
-import { RTKQueryMockState } from "@/types/common";
-import { UserResponse } from "@/types/user.types";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
 
 jest.mock("@/store/api/userProfileApi", () => ({
@@ -35,17 +33,11 @@ jest.mock("@/components/app-menu/AppMenu", () => ({
     ) : null
 }));
 
-const defaultArgs: RTKQueryMockState<UserResponse> = {
-  data: null,
-  isError: false,
-  isLoading: false
-};
 const mockedPhoto = "https://example.com/photo.jpg";
 
-const mockAndRender = (photo?: string | null) => {
+const mockAndRender = (data?: { photo: string | null }) => {
   (useGetUserPhotoQuery as jest.Mock).mockReturnValue({
-    ...defaultArgs,
-    data: photo || defaultArgs.data
+    data: data
   });
 
   renderWithProviders(<HeaderAccountButton />);
@@ -59,7 +51,7 @@ describe("HeaderAccountButton", () => {
   });
 
   it("should render HeaderAccountButton with img", () => {
-    mockAndRender(mockedPhoto);
+    mockAndRender({ photo: mockedPhoto });
 
     const photo = screen.getByTestId(
       "header-account-photo"
@@ -85,7 +77,7 @@ describe("HeaderAccountButton", () => {
   });
 
   it("should not render the photo when no photo is provided", () => {
-    mockAndRender(null);
+    mockAndRender({ photo: null });
 
     const photo = screen.queryByTestId("header-account-photo");
     expect(photo).not.toBeInTheDocument();

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.test.tsx
@@ -6,13 +6,13 @@ import HeaderAccountButton from "@/layouts/header/components/header-buttons/head
 
 import { AppMenuProps, MenuItem } from "@/components/app-menu/AppMenu.types";
 
-import { useGetUserInfoQuery } from "@/store/api/userProfileApi";
+import { useGetUserPhotoQuery } from "@/store/api/userProfileApi";
 import { RTKQueryMockState } from "@/types/common";
 import { UserResponse } from "@/types/user.types";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
 
 jest.mock("@/store/api/userProfileApi", () => ({
-  useGetUserInfoQuery: jest.fn()
+  useGetUserPhotoQuery: jest.fn()
 }));
 jest.mock("@/components/app-menu/AppMenu", () => ({
   __esModule: true,
@@ -40,14 +40,12 @@ const defaultArgs: RTKQueryMockState<UserResponse> = {
   isError: false,
   isLoading: false
 };
-const mockData = {
-  data: { photo: "https://example.com/photo.jpg" }
-};
+const mockedPhoto = "https://example.com/photo.jpg";
 
-const mockAndRender = (args?: RTKQueryMockState<Partial<UserResponse>>) => {
-  (useGetUserInfoQuery as jest.Mock).mockReturnValue({
+const mockAndRender = (photo?: string | null) => {
+  (useGetUserPhotoQuery as jest.Mock).mockReturnValue({
     ...defaultArgs,
-    ...args
+    data: photo || defaultArgs.data
   });
 
   renderWithProviders(<HeaderAccountButton />);
@@ -61,11 +59,14 @@ describe("HeaderAccountButton", () => {
   });
 
   it("should render HeaderAccountButton with img", () => {
-    mockAndRender(mockData);
+    mockAndRender(mockedPhoto);
 
-    const photo = screen.getByTestId("header-account-photo");
+    const photo = screen.getByTestId(
+      "header-account-photo"
+    ) as HTMLImageElement;
+
     expect(photo).toBeInTheDocument();
-    expect(photo).toHaveAttribute("src", mockData.data.photo);
+    expect(photo.src).toBe(mockedPhoto);
   });
 
   it("should open menu and close when menuItem is clicked", async () => {
@@ -81,5 +82,12 @@ describe("HeaderAccountButton", () => {
     await userEvent.click(screen.getByTestId("menu-item-0"));
 
     expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+  });
+
+  it("should not render the photo when no photo is provided", () => {
+    mockAndRender(null);
+
+    const photo = screen.queryByTestId("header-account-photo");
+    expect(photo).not.toBeInTheDocument();
   });
 });

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.tsx
@@ -10,7 +10,7 @@ import AppIconButton from "@/components/app-icon-button/AppIconButton";
 import AppMenu from "@/components/app-menu/AppMenu";
 
 import useLogout from "@/hooks/use-logout/useLogout";
-import { useGetUserInfoQuery } from "@/store/api/userProfileApi";
+import { useGetUserPhotoQuery } from "@/store/api/userProfileApi";
 
 import { rawMenuItems } from "./HeaderAccountButton.constants";
 
@@ -19,15 +19,13 @@ const HeaderAccountButton = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleLogout = useLogout();
-  const { data } = useGetUserInfoQuery();
+  const { data: userPhoto } = useGetUserPhotoQuery();
 
-  const profilePhoto = data?.photo;
-
-  const profileIconOrPhoto = profilePhoto ? (
+  const profileIconOrPhoto = userPhoto ? (
     <AppBox className="header__toolbar-profile-img-wrapper">
       <AppBox
         component="img"
-        src={profilePhoto}
+        src={userPhoto}
         alt="Profile photo"
         className="header__toolbar-profile-img"
         data-testid="header-account-photo"

--- a/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.tsx
+++ b/code/src/layouts/header/components/header-buttons/header-account-button/HeaderAccountButton.tsx
@@ -19,7 +19,9 @@ const HeaderAccountButton = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleLogout = useLogout();
-  const { data: userPhoto } = useGetUserPhotoQuery();
+  const { data } = useGetUserPhotoQuery();
+
+  const userPhoto = data?.photo;
 
   const profileIconOrPhoto = userPhoto ? (
     <AppBox className="header__toolbar-profile-img-wrapper">

--- a/code/src/store/api/userProfileApi.ts
+++ b/code/src/store/api/userProfileApi.ts
@@ -2,7 +2,7 @@ import { rtkQueryTags } from "@/constants/api-tags";
 import { httpMethods } from "@/constants/methods";
 import { URLS } from "@/constants/requests";
 import { appApi } from "@/store/api/appApi";
-import { UserResponse } from "@/types/user.types";
+import { UserPhotoResponse, UserResponse } from "@/types/user.types";
 
 export const userProfileApi = appApi.injectEndpoints({
   endpoints: (build) => ({
@@ -38,11 +38,11 @@ export const userProfileApi = appApi.injectEndpoints({
       }),
       invalidatesTags: [rtkQueryTags.USER_PROFILE, rtkQueryTags.USER_PHOTO]
     }),
-    getUserPhoto: build.query<string, void>({
+    getUserPhoto: build.query<UserPhotoResponse, void>({
       query: () => ({
         url: URLS.userInfo.photo.get
       }),
-      providesTags: [rtkQueryTags.USER_PROFILE, rtkQueryTags.USER_PHOTO],
+      providesTags: [rtkQueryTags.USER_PROFILE, rtkQueryTags.USER_PHOTO]
     })
   })
 });

--- a/code/src/store/api/userProfileApi.ts
+++ b/code/src/store/api/userProfileApi.ts
@@ -37,6 +37,12 @@ export const userProfileApi = appApi.injectEndpoints({
         method: httpMethods.delete
       }),
       invalidatesTags: [rtkQueryTags.USER_PROFILE, rtkQueryTags.USER_PHOTO]
+    }),
+    getUserPhoto: build.query<string, void>({
+      query: () => ({
+        url: URLS.userInfo.photo.get
+      }),
+      providesTags: [rtkQueryTags.USER_PROFILE, rtkQueryTags.USER_PHOTO],
     })
   })
 });
@@ -45,5 +51,6 @@ export const {
   useGetUserInfoQuery,
   useUpdateUserInfoMutation,
   useUpdateUserPhotoMutation,
+  useGetUserPhotoQuery,
   useDeleteUserPhotoMutation
 } = userProfileApi;

--- a/code/src/types/user.types.ts
+++ b/code/src/types/user.types.ts
@@ -21,6 +21,8 @@ export type UserResponse = User & {
   photo: string | null;
 };
 
+export type UserPhotoResponse = Pick<UserResponse, "photo">;
+
 export type UserFromServer = BaseUser & {
   sub: string;
   scope: UserRole;


### PR DESCRIPTION
### Description

Updated the endpoint of the photo in the header. This endpoint will take only a photo instead of all info about the user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Profile photo now fetched via a dedicated endpoint, improving display in the header account button.
- Bug Fixes
  - Graceful handling when no profile photo is available: shows the default icon without rendering a broken image.
- Tests
  - Updated tests to cover profile photo rendering and the no-photo fallback behavior.
- Documentation
  - Type surface extended to include a lightweight photo-only response, clarifying expected data for photo retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->