### PR TITLE
[GS3-100]  Added same size to icon and img

### DIFF
--- a/code/src/layouts/header/components/header-toolbar/HeaderToolbar.scss
+++ b/code/src/layouts/header/components/header-toolbar/HeaderToolbar.scss
@@ -4,7 +4,7 @@
   padding: spacing(3) spacing(4);
   background-color: var(--color-surface);
   color: var(--color-text);
-}  
+}
 
 .header__toolbar {
   display: flex;
@@ -22,6 +22,8 @@
   }
 
   &-icon {
+    width: 30px;
+    height: 30px;
     color: var(--color-text, $black);
   }
 
@@ -30,8 +32,8 @@
   }
 
   &-profile-img-wrapper {
-    width: 40px;
-    height: 40px;
+    width: 30px;
+    height: 30px;
     border-radius: 50%;
     overflow: hidden;
     display: flex;


### PR DESCRIPTION
### Description

Fixed jumping header. Added same size to icon and image

https://github.com/user-attachments/assets/355041a8-04eb-497b-b429-8910b1bbd4eb





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized header toolbar icons to 30×30 for visual consistency.
  * Reduced profile image display to 30×30, making the header more compact.
  * Improved alignment and spacing in the header for a cleaner look.
  * Purely visual refinements; no functional changes for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->