### PR TITLE
[GS3-12] Fixed bestsellers empty view

### DIFF
--- a/code/src/containers/best-sellers/BestSellers.test.tsx
+++ b/code/src/containers/best-sellers/BestSellers.test.tsx
@@ -70,13 +70,13 @@ describe("BestSellers", () => {
   });
 
   test("should render loading state", () => {
-    renderAndMock({ isLoading: true, data: mockProductsResponse });
+    renderAndMock({ isLoading: true, data: null });
     const loading = screen.getByText("Loading...");
     expect(loading).toBeInTheDocument();
   });
 
   test("should render error state", () => {
-    renderAndMock({ isError: true, data: mockProductsResponse });
+    renderAndMock({ isError: true, data: null });
     const error = screen.getByText("Error!");
     expect(error).toBeInTheDocument();
   });

--- a/code/src/containers/best-sellers/BestSellers.test.tsx
+++ b/code/src/containers/best-sellers/BestSellers.test.tsx
@@ -46,7 +46,7 @@ const renderAndMock = (
 
 describe("BestSellers", () => {
   test("Should render bestSellers header", () => {
-    renderAndMock();
+    renderAndMock({ data: mockProductsResponse });
 
     const bestSellersHeader = screen.getByText(/bestSellers.header/i);
 
@@ -70,19 +70,19 @@ describe("BestSellers", () => {
   });
 
   test("should render loading state", () => {
-    renderAndMock({ isLoading: true });
+    renderAndMock({ isLoading: true, data: mockProductsResponse });
     const loading = screen.getByText("Loading...");
     expect(loading).toBeInTheDocument();
   });
 
   test("should render error state", () => {
-    renderAndMock({ isError: true });
+    renderAndMock({ isError: true, data: mockProductsResponse });
     const error = screen.getByText("Error!");
     expect(error).toBeInTheDocument();
   });
 
   test("should render the button with correct props", () => {
-    renderAndMock();
+    renderAndMock({ data: mockProductsResponse });
 
     const button = screen.getByRole("link", { name: /bestSellers.button/i });
     expect(button).toHaveAttribute(

--- a/code/src/containers/best-sellers/BestSellers.tsx
+++ b/code/src/containers/best-sellers/BestSellers.tsx
@@ -25,7 +25,7 @@ const BestSellers = () => {
     tags: ""
   });
 
-  if (!bestsellersData?.content || bestsellersData.content.length === 0) {
+  if (!isLoading && !isError && !bestsellersData?.content?.length) {
     return null;
   }
 

--- a/code/src/containers/best-sellers/BestSellers.tsx
+++ b/code/src/containers/best-sellers/BestSellers.tsx
@@ -25,6 +25,10 @@ const BestSellers = () => {
     tags: ""
   });
 
+  if (!bestsellersData?.content || bestsellersData.content.length === 0) {
+    return null;
+  }
+
   return (
     <PageWrapper
       id="bestsellers-section"


### PR DESCRIPTION
### Description 
When there are no bestsellers products bestseller container will not be shown on the home page

<img width="1908" height="920" alt="image" src="https://github.com/user-attachments/assets/a011d444-719a-4a78-87ce-886044b73710" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Best Sellers section no longer appears when there are no items, preventing empty/blank sections while preserving loading and error displays.

- Refactor
  - Component rendering flow adjusted to skip the Best Sellers area when content is absent; public behavior remains unchanged.

- Tests
  - Updated test setup to always provide sample data so the populated rendering path is consistently exercised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->