### PR TITLE
[GS3-101] Fixed max columns and loading 

### DIFF
--- a/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
+++ b/code/src/containers/user-account/my-wishlist/MyWishlist.tsx
@@ -103,6 +103,7 @@ const MyWishlist = () => {
         isLoading={isLoading}
         loadingItemsCount={10}
         wishlist={productsList ?? []}
+        maxColumns={3}
       />
       <PaginationBlock
         page={page}

--- a/code/src/containers/user-account/view-history/UserViewHistory.module.scss
+++ b/code/src/containers/user-account/view-history/UserViewHistory.module.scss
@@ -16,7 +16,7 @@
   &_products {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: spacing(16);
+    gap: spacing(5);
   }
 
   &_header {

--- a/code/src/containers/user-account/view-history/UserViewHistory.module.scss
+++ b/code/src/containers/user-account/view-history/UserViewHistory.module.scss
@@ -64,7 +64,7 @@
 
   &_loading {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     grid-template-rows: repeat(2, auto);
     gap: 1rem;
   }

--- a/code/src/containers/user-account/view-history/UserViewHistory.test.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.test.tsx
@@ -160,7 +160,7 @@ describe("UserViewHistory", () => {
     renderAndMock({ isLoading: true });
     const skeletons = screen.queryAllByTestId("spa-product-skeleton");
 
-    expect(skeletons.length).toBe(10);
+    expect(skeletons.length).toBe(6);
   });
 
   it("should call clearAll and open modal", async () => {

--- a/code/src/containers/user-account/view-history/UserViewHistory.tsx
+++ b/code/src/containers/user-account/view-history/UserViewHistory.tsx
@@ -89,7 +89,7 @@ const UserViewHistory = () => {
     if (isLoading) {
       return (
         <AppBox className={styles.viewHistory_loading}>
-          {repeatComponent(<ProductSkeleton />, 10)}
+          {repeatComponent(<ProductSkeleton />, 6)}
         </AppBox>
       );
     }
@@ -120,6 +120,7 @@ const UserViewHistory = () => {
           isViewHistory
           wishlist={wishlist}
           className={styles.viewHistory_products}
+          maxColumns={3}
         />
       </AppBox>
     );


### PR DESCRIPTION
### Description 

Added max columns 3 to the Wishlist and View History. Also changed loading to the corresponding 6 cards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized product grids to a 3-column layout in Wishlist and View History for a more consistent browsing experience.
  * Reduced loading-state density in View History from 10 to 6 skeleton items for a cleaner, faster-feeling UI.
  * Adjusted loading-grid spacing to align with the 3-column layout for visual consistency.

* **Tests**
  * Updated View History loading-state test expectations to reflect the new 6-skeleton layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->