### PR TITLE
[GS-102] Hided `Change password` button

### DIFF
--- a/code/src/components/profile-email-password/EmailAndPassword.module.scss
+++ b/code/src/components/profile-email-password/EmailAndPassword.module.scss
@@ -12,5 +12,6 @@
 
   &_changeButton {
     width: clamp(180px, 15vw, 300px);
+    display: none;
   }
 }


### PR DESCRIPTION
Hided `Change password` button:

Before:
<img width="460" height="322" alt="image" src="https://github.com/user-attachments/assets/3c9ccff3-9548-426e-ab71-c5f30834719f" />

After:
<img width="537" height="347" alt="image" src="https://github.com/user-attachments/assets/e20c452f-f47d-42dc-8259-2fc98403eb07" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The “Change” button in Profile → Email & Password is now hidden, removing it from view and interaction.
  * Layout and spacing remain consistent; no other visual elements are affected.
  * Applies across desktop and mobile views to ensure a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->