### PR TITLE
[GS2-225] Integrate Pexels image modal

### DIFF
--- a/code/src/containers/forms/product-form/ProductForm.scss
+++ b/code/src/containers/forms/product-form/ProductForm.scss
@@ -34,9 +34,17 @@ $gridGapHalf: calc($gridGap / 2);
     padding: spacing(8);
     background-color: var(--color-surface);
     color: var(--color-text);
+
     * {
       color: inherit;
     }
+  }
+
+  &__image-search-button {
+    border-radius: spacing(1);
+    height: 47px;
+    margin-top: spacing(4);
+    color: $light;
   }
 
   &__container {
@@ -167,17 +175,13 @@ $gridGapHalf: calc($gridGap / 2);
     padding: spacing(1) spacing(3);
 
     &-label {
-      color: var(
-        --new-rpoduct-form-checkbox-color,
-        $light-alpha
-      ) !important; // To rewrite mui styles and styles setted in AppCheckbox
+      color: var(--new-rpoduct-form-checkbox-color,
+          $light-alpha ) !important; // To rewrite mui styles and styles setted in AppCheckbox
     }
 
     & svg {
-      fill: var(
-        --new-rpoduct-form-checkbox-color,
-        $light-alpha
-      ) !important; // To rewrite mui styles and styles setted in AppCheckbox
+      fill: var(--new-rpoduct-form-checkbox-color,
+          $light-alpha ) !important; // To rewrite mui styles and styles setted in AppCheckbox
     }
   }
 
@@ -215,13 +219,9 @@ $gridGapHalf: calc($gridGap / 2);
 
   &__language-button--active {
     color: var(--product-form-language-button-active-text-color, $white);
-    background-color: var(
-      --product-form-language-button-active-background-color,
-      $product-form-language-button-color
-    ) !important; // to overwrite mui styles
-    border-color: var(
-      --product-form-language-button-active-color,
-      $product-form-language-button-color
-    );
+    background-color: var(--product-form-language-button-active-background-color,
+        $product-form-language-button-color ) !important; // to overwrite mui styles
+    border-color: var(--product-form-language-button-active-color,
+        $product-form-language-button-color );
   }
 }

--- a/code/src/containers/forms/product-form/ProductForm.scss
+++ b/code/src/containers/forms/product-form/ProductForm.scss
@@ -34,7 +34,6 @@ $gridGapHalf: calc($gridGap / 2);
     padding: spacing(8);
     background-color: var(--color-surface);
     color: var(--color-text);
-
     * {
       color: inherit;
     }
@@ -175,13 +174,17 @@ $gridGapHalf: calc($gridGap / 2);
     padding: spacing(1) spacing(3);
 
     &-label {
-      color: var(--new-rpoduct-form-checkbox-color,
-          $light-alpha ) !important; // To rewrite mui styles and styles setted in AppCheckbox
+      color: var(
+        --new-rpoduct-form-checkbox-color,
+        $light-alpha
+      ) !important; // To rewrite mui styles and styles setted in AppCheckbox
     }
 
     & svg {
-      fill: var(--new-rpoduct-form-checkbox-color,
-          $light-alpha ) !important; // To rewrite mui styles and styles setted in AppCheckbox
+      fill: var(
+        --new-rpoduct-form-checkbox-color,
+        $light-alpha
+      ) !important; // To rewrite mui styles and styles setted in AppCheckbox
     }
   }
 
@@ -219,9 +222,13 @@ $gridGapHalf: calc($gridGap / 2);
 
   &__language-button--active {
     color: var(--product-form-language-button-active-text-color, $white);
-    background-color: var(--product-form-language-button-active-background-color,
-        $product-form-language-button-color ) !important; // to overwrite mui styles
-    border-color: var(--product-form-language-button-active-color,
-        $product-form-language-button-color );
+    background-color: var(
+      --product-form-language-button-active-background-color,
+      $product-form-language-button-color
+    ) !important; // to overwrite mui styles
+    border-color: var(
+      --product-form-language-button-active-color,
+      $product-form-language-button-color
+    );
   }
 }

--- a/code/src/containers/forms/product-form/components/image/Image.test.tsx
+++ b/code/src/containers/forms/product-form/components/image/Image.test.tsx
@@ -7,6 +7,7 @@ import {
   ProductFormRegisterFunction
 } from "@/containers/forms/product-form/ProductForm.types";
 import ImagePreview from "@/containers/forms/product-form/components/image/Image";
+import { useModalContext } from "@/context/modal/ModalContext";
 
 import getTagIn from "@/utils/get-tag-in/getTagIn";
 import typeIntoInput from "@/utils/type-into-input/typeIntoInput";
@@ -19,6 +20,23 @@ jest.mock("react-hook-form", () => ({
   Controller: jest.fn()
 }));
 
+jest.mock("@/context/modal/ModalContext", () => ({
+  useModalContext: jest.fn()
+}));
+
+const mockOpenModal = jest.fn();
+const mockCloseModal = jest.fn();
+const mockToggleModal = jest.fn();
+
+beforeEach(() => {
+  (useModalContext as jest.Mock).mockReturnValue({
+    openModal: mockOpenModal,
+    closeModal: mockCloseModal,
+    toggleModal: mockToggleModal
+  });
+});
+
+// Mock error for input
 const imageError = {
   image: {
     message: "Image error"
@@ -26,8 +44,9 @@ const imageError = {
 } as unknown as ProductFormFieldErrors;
 
 const controllerPropsWithValue = {
-  value: "https://test.com/image.jpg"
-} as ControllerRenderProps;
+  value: "https://test.com/image.jpg",
+  onChange: jest.fn()
+} as unknown as ControllerRenderProps;
 
 const registerFunction = (() => ({})) as unknown as ProductFormRegisterFunction;
 const controlFunction = (() => ({})) as unknown as ProductFormControl;
@@ -38,9 +57,7 @@ const renderAndMock = (
 ) => {
   (Controller as jest.Mock).mockImplementation(
     ({ render }: MockControllerProps) =>
-      render({
-        field: controllerRenderProps
-      })
+      render({ field: controllerRenderProps })
   );
 
   render(
@@ -52,8 +69,8 @@ const renderAndMock = (
   );
 };
 
-describe("Test Image", () => {
-  test("should render input and image preview text", () => {
+describe("ImagePreview Component", () => {
+  test("renders input and default image preview text", () => {
     renderAndMock();
 
     const imageInput = screen.getByRole("textbox");
@@ -63,7 +80,7 @@ describe("Test Image", () => {
     expect(imagePreviewText).toBeInTheDocument();
   });
 
-  test("Should render helper text and change styles when error", () => {
+  test("renders helper text and error styles when error exists", () => {
     renderAndMock(undefined, imageError);
 
     const imageHelperText = screen.getByText("Image error");
@@ -73,7 +90,7 @@ describe("Test Image", () => {
     expect(imageInput.closest(".Mui-error")).toBeTruthy();
   });
 
-  test("Should not display error by default", () => {
+  test("does not display error styles by default", () => {
     renderAndMock();
 
     const imageInput = getTagIn("product-form-image-input");
@@ -81,34 +98,31 @@ describe("Test Image", () => {
     expect(imageInput.closest(".Mui-error")).toBeFalsy();
   });
 
-  test("Should show error if image is invalid and clear it when valid value provided", async () => {
-    renderAndMock({
-      value: "https://test.com/image.jpg",
-      onChange: () => {}
-    } as ControllerRenderProps);
+  test("shows error when image fails to load and clears on valid input", async () => {
+    renderAndMock(controllerPropsWithValue);
 
     const image = screen.getByTestId("product-form-image-preview");
     fireEvent.error(image);
 
-    const error = screen.getByText("productForm.image.previewError");
-    expect(error).toBeInTheDocument();
+    const errorText = screen.getByText("productForm.image.previewError");
+    expect(errorText).toBeInTheDocument();
 
     const imageInput = getTagIn("product-form-image-input");
     await typeIntoInput(imageInput, "https://test.com/example.jpg");
 
-    const imageEl = screen.getByTestId("product-form-image-preview");
-    expect(imageEl).toBeInTheDocument();
+    const updatedImage = screen.getByTestId("product-form-image-preview");
+    expect(updatedImage).toBeInTheDocument();
   });
 
-  test("Should show image when image input is filled", async () => {
+  test("displays image when input has value", () => {
     renderAndMock(controllerPropsWithValue);
 
     const image = screen.getByTestId("product-form-image-preview");
-
+    
     expect(image).toBeInTheDocument();
   });
 
-  test("Should show default image text if image input is empty", () => {
+  test("displays default preview text if input is empty", () => {
     renderAndMock();
 
     const imageText = screen.getByText("productForm.image.preview");

--- a/code/src/containers/forms/product-form/components/image/Image.tsx
+++ b/code/src/containers/forms/product-form/components/image/Image.tsx
@@ -59,7 +59,7 @@ const Image = ({ errors, control }: ProductFormImageSectionProps) => {
     const handleImageModalOpen = () => {
       openModal(
         <ImageSearchModal
-          onSelect={(url) => onChange(url)}
+          onSelect={onChange}
         />
       );
     };

--- a/code/src/containers/forms/product-form/components/image/Image.tsx
+++ b/code/src/containers/forms/product-form/components/image/Image.tsx
@@ -5,10 +5,14 @@ import {
   ProductFormImageSectionProps,
   ProductFormValues
 } from "@/containers/forms/product-form/ProductForm.types";
+import ImageSearchModal from "@/containers/modals/image-search-modal/ImageSearchModal";
 
 import AppBox from "@/components/app-box/AppBox";
 import AppInput from "@/components/app-input/AppInput";
 import AppTypography from "@/components/app-typography/AppTypography";
+import AppButton from "@/components/app-button/AppButton";
+
+import { useModalContext } from "@/context/modal/ModalContext";
 
 type ControllerRenderFunctionProps = {
   field: ControllerRenderProps<ProductFormValues, "image">;
@@ -16,6 +20,7 @@ type ControllerRenderFunctionProps = {
 
 const Image = ({ errors, control }: ProductFormImageSectionProps) => {
   const [isError, setIsError] = useState(false);
+  const { openModal } = useModalContext();
 
   const handleImgError = () => {
     setIsError(true);
@@ -75,6 +80,13 @@ const Image = ({ errors, control }: ProductFormImageSectionProps) => {
             onChange={handleChange}
             {...handlers}
           />
+          <AppButton onClick={() => openModal(
+            <ImageSearchModal
+              onSelect={(url) => onChange(url)}
+            />
+          )}>
+            <AppTypography translationKey="productForm.image.searchImageButton" />
+          </AppButton>
         </AppBox>
       </AppBox>
     );

--- a/code/src/containers/forms/product-form/components/image/Image.tsx
+++ b/code/src/containers/forms/product-form/components/image/Image.tsx
@@ -56,6 +56,14 @@ const Image = ({ errors, control }: ProductFormImageSectionProps) => {
         />
       );
 
+    const handleImageModalOpen = () => {
+      openModal(
+        <ImageSearchModal
+          onSelect={(url) => onChange(url)}
+        />
+      );
+    };
+
     return (
       <AppBox className="product-form__container product-form__image-section">
         <AppBox className="product-form__header">
@@ -80,11 +88,11 @@ const Image = ({ errors, control }: ProductFormImageSectionProps) => {
             onChange={handleChange}
             {...handlers}
           />
-          <AppButton onClick={() => openModal(
-            <ImageSearchModal
-              onSelect={(url) => onChange(url)}
-            />
-          )}>
+          <AppButton
+            className="product-form__image-search-button"
+            fullWidth
+            onClick={handleImageModalOpen}
+          >
             <AppTypography translationKey="productForm.image.searchImageButton" />
           </AppButton>
         </AppBox>

--- a/code/src/containers/forms/product-form/messages/en.json
+++ b/code/src/containers/forms/product-form/messages/en.json
@@ -6,6 +6,7 @@
   "productForm.discountPercentage.label": "Discount, %",
   "productForm.inputLabel.image": "Image URL",
   "productForm.inputLabel.status": "Visible to customers",
+  "productForm.image.searchImageButton": "Search on Pexels",
   "productForm.update.submit": "Update product",
   "productForm.create.submit": "Create product",
   "productForm.creation.success": "Product successfully created",

--- a/code/src/containers/forms/product-form/messages/uk.json
+++ b/code/src/containers/forms/product-form/messages/uk.json
@@ -6,6 +6,7 @@
   "productForm.discountPercentage.label": "Знижка, %",
   "productForm.inputLabel.image": "URL зображення",
   "productForm.inputLabel.status": "Видимий для покупців",
+  "productForm.image.searchImageButton": "Пошук у Pexels",
   "productForm.update.submit": "Оновити товар",
   "productForm.create.submit": "Створити товар",
   "productForm.creation.success": "Продукт успішно створено",

--- a/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.tsx
+++ b/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.tsx
@@ -69,7 +69,7 @@ const ImageSearch = ({ onSelect, onSearch }: ImageSearchProps) => {
             {message}
           </AppTypography>
         )}
-        {images?.length && (
+        {images && images.length > 0 && (
           <ImageGrid
             images={images.slice(0, MAX_IMAGES)}
             selectedImage={selectedImage}


### PR DESCRIPTION
* Added button, modal and translations to Image field.
* Added styling for the new image-search button (size, spacing, color).
* Updated tests to cover the new modal interaction and image input behaviors.
* Fixed description when no images is found in the modal.

<img width="1257" height="893" alt="image" src="https://github.com/user-attachments/assets/790a225e-1ef7-4ffd-a67e-cc5235c94b07" />
<img width="1298" height="921" alt="image" src="https://github.com/user-attachments/assets/f78e6f95-40ab-4e0a-84e4-b3e3ae517527" />
<img width="1314" height="802" alt="image" src="https://github.com/user-attachments/assets/f0640876-7732-4e78-a24d-62ccca644505" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated modal-based image search into the product form with a "Search on Pexels" trigger.
  * Added English and Ukrainian translations for the new image search button.

* **Style**
  * Added styling for the image search button to match form layout.

* **Tests**
  * Updated unit tests to cover the image search modal integration and image preview behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->