### PR TITLE
[GS2-261] Added Suggested keywords to Search image modal

### DIFF
--- a/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.constants.ts
+++ b/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.constants.ts
@@ -1,1 +1,3 @@
 export const MAX_IMAGES = 8;
+
+export const suggestedKeywords = ["Smartphone", "Laptop", "Technology"];

--- a/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.tsx
+++ b/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.tsx
@@ -58,7 +58,7 @@ const ImageSearch = ({ onSelect, onSearch }: ImageSearchProps) => {
           })}
           onChange={handleSearchChange}
           onClear={handleClearSearch}
-          onSearch={() => handleSearch()}
+          onSearch={handleSearch}
           hideSearchIcon
           className={styles.searchContainer_searchInput}
         />

--- a/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.tsx
+++ b/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.tsx
@@ -10,7 +10,8 @@ import AppLoader from "@/components/app-loader/AppLoader";
 import { ImageSearchProps } from "@/containers/modals/image-search-modal/components/image-search/ImageSearch.types";
 import ImageGrid from "@/containers/modals/image-search-modal/components/image-grid/ImageGrid";
 import { useImageSearch } from "@/containers/modals/image-search-modal/hooks/useImageSearch";
-import { MAX_IMAGES } from "@/containers/modals/image-search-modal/components/image-search/ImageSearch.constants";
+import SuggestedKeywords from "@/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords";
+import { MAX_IMAGES, suggestedKeywords } from "@/containers/modals/image-search-modal/components/image-search/ImageSearch.constants";
 import { useModalContext } from "@/context/modal/ModalContext";
 import cn from "@/utils/cn/cn";
 
@@ -22,6 +23,7 @@ const ImageSearch = ({ onSelect, onSearch }: ImageSearchProps) => {
 
   const {
     searchValue,
+    setSearchValue,
     selectedImage,
     images,
     isLoading,
@@ -41,6 +43,11 @@ const ImageSearch = ({ onSelect, onSearch }: ImageSearchProps) => {
     closeModal();
   };
 
+  const handleKeywordClick = (keyword: string) => {
+    setSearchValue(keyword);
+    handleSearch(keyword);
+  };
+
   return (
     <AppContainer className={styles.searchContainer} data-testid="image-search-container">
       <AppBox className={styles.searchContainer_searchInputWrapper}>
@@ -51,9 +58,17 @@ const ImageSearch = ({ onSelect, onSearch }: ImageSearchProps) => {
           })}
           onChange={handleSearchChange}
           onClear={handleClearSearch}
-          onSearch={handleSearch}
+          onSearch={() => handleSearch()}
           hideSearchIcon
           className={styles.searchContainer_searchInput}
+        />
+      </AppBox>
+      <AppBox
+        sx={{ display: 'flex', justifyContent: 'center', marginTop: '10px' }}
+      >
+        <SuggestedKeywords
+          keywords={suggestedKeywords}
+          onKeywordClick={handleKeywordClick}
         />
       </AppBox>
       <AppBox className={styles.searchContainer_imageContent}>

--- a/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.module.scss
+++ b/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.module.scss
@@ -1,0 +1,28 @@
+.suggestedKeywords {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+
+
+    &_box {
+        padding: 4px 12px;
+        border-radius: 16px;
+        border-color: var(--color-bg);
+        border-width: spacing(2);
+        box-shadow: var(--shadow);
+        color: var(--color-text);
+        transition: background-color 0.2s ease-in-out;
+        cursor: pointer;
+
+        &:hover,
+        &:focus-within {
+            background-color: var(--color-bg);
+            transform: scale(1.005);
+        }
+    }
+
+    &_keyword {
+        color: var(--color-muted);
+    }
+}

--- a/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.module.scss
+++ b/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.module.scss
@@ -16,9 +16,11 @@
         cursor: pointer;
 
         &:hover,
-        &:focus-within {
+        &:focus {
             background-color: var(--color-bg);
             transform: scale(1.005);
+            border-color: var(--color-bg);
+            outline: none;
         }
     }
 

--- a/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.test.tsx
+++ b/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import SuggestedKeywords from "@/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords";
+
+describe("SuggestedKeywords", () => {
+    test("renders all provided keywords", () => {
+        const keywords = ["laptop", "smartphone"];
+        const onKeywordClick = jest.fn();
+
+        render(<SuggestedKeywords keywords={keywords} onKeywordClick={onKeywordClick} />);
+
+        // each keyword should be rendered
+        expect(screen.getByText("laptop")).toBeInTheDocument();
+        expect(screen.getByText("smartphone")).toBeInTheDocument();
+    });
+
+    test("calls onKeywordClick with correct keyword when a keyword is clicked", () => {
+        const keywords = ["laptop", "smartphone"];
+        const onKeywordClick = jest.fn();
+
+        render(<SuggestedKeywords keywords={keywords} onKeywordClick={onKeywordClick} />);
+
+        const laptopNode = screen.getByText("laptop");
+        fireEvent.click(laptopNode);
+
+        expect(onKeywordClick).toHaveBeenCalledTimes(1);
+        expect(onKeywordClick).toHaveBeenCalledWith("laptop");
+    });
+
+    test("does not render any keyword when keywords array is empty", () => {
+        const keywords: string[] = [];
+        const onKeywordClick = jest.fn();
+
+        const { container } = render(<SuggestedKeywords keywords={keywords} onKeywordClick={onKeywordClick} />);
+
+        expect(screen.queryByText("laptop")).not.toBeInTheDocument();
+        expect(screen.queryByText("smartphone")).not.toBeInTheDocument();
+        /*
+        * The wrapper should be rendered, but it must contain no keyword items.
+        * This verifies that no child elements with text content are present.
+        */
+        const textNodes = Array.from(container.querySelectorAll("div")).filter((n) => n.textContent?.trim());
+        expect(textNodes.length).toBe(0);
+    });
+});

--- a/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.tsx
+++ b/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.tsx
@@ -15,6 +15,7 @@ const SuggestedKeywords = ({ keywords, onKeywordClick }: SuggestedKeywordsProps)
                     className={styles.suggestedKeywords_box}
                     onClick={() => onKeywordClick(keyword)}
                     variant="outlined"
+                    type="button"
                 >
                     <AppTypography className={styles.suggestedKeywords_keyword}>
                         {keyword}

--- a/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.tsx
+++ b/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.tsx
@@ -1,0 +1,27 @@
+import AppBox from "@/components/app-box/AppBox";
+import AppTypography from "@/components/app-typography/AppTypography";
+
+import { SuggestedKeywordsProps } from "@/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.types";
+
+import * as styles from "@/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.module.scss";
+
+const SuggestedKeywords = ({ keywords, onKeywordClick }: SuggestedKeywordsProps) => {
+    return (
+        <AppBox className={styles.suggestedKeywords}>
+            {keywords.map((keyword) => (
+                <AppBox
+                    key={keyword}
+                    className={styles.suggestedKeywords_box}
+                    onClick={() => onKeywordClick(keyword)}
+                >
+                    <AppTypography className={styles.suggestedKeywords_keyword}>
+                        {keyword}
+                    </AppTypography>
+                </AppBox>
+            ))
+            }
+        </AppBox >
+    );
+};
+
+export default SuggestedKeywords;

--- a/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.tsx
+++ b/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.tsx
@@ -1,4 +1,5 @@
 import AppBox from "@/components/app-box/AppBox";
+import AppButton from "@/components/app-button/AppButton";
 import AppTypography from "@/components/app-typography/AppTypography";
 
 import { SuggestedKeywordsProps } from "@/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.types";
@@ -9,15 +10,16 @@ const SuggestedKeywords = ({ keywords, onKeywordClick }: SuggestedKeywordsProps)
     return (
         <AppBox className={styles.suggestedKeywords}>
             {keywords.map((keyword) => (
-                <AppBox
+                <AppButton
                     key={keyword}
                     className={styles.suggestedKeywords_box}
                     onClick={() => onKeywordClick(keyword)}
+                    variant="outlined"
                 >
                     <AppTypography className={styles.suggestedKeywords_keyword}>
                         {keyword}
                     </AppTypography>
-                </AppBox>
+                </AppButton>
             ))
             }
         </AppBox >

--- a/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.types.ts
+++ b/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.types.ts
@@ -1,0 +1,4 @@
+export type SuggestedKeywordsProps = {
+  keywords: string[];
+  onKeywordClick: (keyword: string) => void;
+}

--- a/code/src/containers/modals/image-search-modal/hooks/useImageSearch.ts
+++ b/code/src/containers/modals/image-search-modal/hooks/useImageSearch.ts
@@ -22,9 +22,16 @@ export const useImageSearch = (onSearch?: (value: string) => void) => {
         onSearch?.("");
     };
 
-    const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => setSearchValue(e.target.value);
+    const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+        setSearchValue(e.target.value);
+    };
+
     const handleClearSearch = () => resetSearch();
-    const handleSearch = () => onSearch?.(searchValue);
+
+    const handleSearch = (value?: string) => {
+        const searchTerm = value ?? searchValue;
+        onSearch?.(searchTerm);
+    };
 
     const message = getImageSearchStatus({
         error,
@@ -34,6 +41,7 @@ export const useImageSearch = (onSearch?: (value: string) => void) => {
 
     return {
         searchValue,
+        setSearchValue,
         selectedImage,
         images,
         isLoading,


### PR DESCRIPTION
Image search modal now shows clickable suggested keywords (e.g., "Smartphone", "Laptop", "Technology") so users can start searches with one tap; clicking a keyword populates the search and runs it.

* Created `SuggestedKeywords` components
* Added it to the modal
* Added styles and relevant unit tests

<img width="449" height="435" alt="image" src="https://github.com/user-attachments/assets/1abc42d6-78fc-4344-91b9-b2bccb38fa1a" />

<img width="452" height="427" alt="image" src="https://github.com/user-attachments/assets/c21eba5a-9fa4-4f96-a4a8-60a961e589fd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added suggested keyword recommendations ("Smartphone", "Laptop", "Technology") in the image search modal for quick access.
  * Clicking a suggested keyword populates the search input and triggers the search immediately; keywords appear beneath the search field.

* **Styles**
  * New styling for suggested keyword chips with hover and focus effects.

* **Tests**
  * Added tests covering rendering and click behavior of suggested keywords.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->