### PR TITLE
[GS2-234] Added Cypress E2E for Image search modal

### DIFF
--- a/code/src/containers/forms/product-form/components/image/Image.tsx
+++ b/code/src/containers/forms/product-form/components/image/Image.tsx
@@ -92,6 +92,7 @@ const Image = ({ errors, control }: ProductFormImageSectionProps) => {
             className="product-form__image-search-button"
             fullWidth
             onClick={handleImageModalOpen}
+            data-cy="product-form-image-search-button"
           >
             <AppTypography translationKey="productForm.image.searchImageButton" />
           </AppButton>

--- a/code/src/containers/modals/image-search-modal/ImageSearchModal.tsx
+++ b/code/src/containers/modals/image-search-modal/ImageSearchModal.tsx
@@ -30,7 +30,7 @@ const ImageSearchModal = ({ onSelect }: ImageSearchModalProps) => {
   };
 
   return (
-    <AppBox className={styles.imageSearchModal}>
+    <AppBox className={styles.imageSearchModal} data-cy="image-search-modal">
       <AppIconButton
         className={styles.imageSearchModal_closeIcon}
         onClick={closeModal}

--- a/code/src/containers/modals/image-search-modal/components/image-grid/ImageGrid.tsx
+++ b/code/src/containers/modals/image-search-modal/components/image-grid/ImageGrid.tsx
@@ -7,7 +7,7 @@ import * as styles from "@/containers/modals/image-search-modal/components/image
 
 const ImageGrid = ({ images, selectedImage, onSelect }: ImageGridProps) => {
   return (
-    <AppBox className={styles.imageGrid}>
+    <AppBox className={styles.imageGrid} data-cy="image-search-results">
       {images.map((url) => (
         <AppBox
           key={url}
@@ -15,6 +15,7 @@ const ImageGrid = ({ images, selectedImage, onSelect }: ImageGridProps) => {
             styles.imageGrid_imageWrapper,
             selectedImage === url && styles.imageGrid_selectedImage
           )}
+          data-cy={selectedImage === url ? "selected-image" : null}
           onClick={(e) => {
             e.stopPropagation();
             onSelect(url);

--- a/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.tsx
+++ b/code/src/containers/modals/image-search-modal/components/image-search/ImageSearch.tsx
@@ -61,6 +61,7 @@ const ImageSearch = ({ onSelect, onSearch }: ImageSearchProps) => {
           onSearch={handleSearch}
           hideSearchIcon
           className={styles.searchContainer_searchInput}
+          data-cy="image-search-input"
         />
       </AppBox>
       <AppBox
@@ -94,6 +95,7 @@ const ImageSearch = ({ onSelect, onSearch }: ImageSearchProps) => {
       </AppBox>
       <AppBox className={styles.searchContainer_buttonWrapper}>
         <AppButton
+          data-cy="image-search-confirm-button"
           onClick={handleConfirm}
           disabled={!selectedImage}
           className={cn(

--- a/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.tsx
+++ b/code/src/containers/modals/image-search-modal/components/suggested-keywords/SuggestedKeywords.tsx
@@ -8,7 +8,7 @@ import * as styles from "@/containers/modals/image-search-modal/components/sugge
 
 const SuggestedKeywords = ({ keywords, onKeywordClick }: SuggestedKeywordsProps) => {
     return (
-        <AppBox className={styles.suggestedKeywords}>
+        <AppBox className={styles.suggestedKeywords} data-cy="suggested-keywords">
             {keywords.map((keyword) => (
                 <AppButton
                     key={keyword}

--- a/e2e/cypress/test_module/cypress.config.ts
+++ b/e2e/cypress/test_module/cypress.config.ts
@@ -5,11 +5,9 @@ import addTestCoveragePlugin from "@cypress/code-coverage/task";
 import addWebpackPreprocessorPlugin from "./cypress/plugins/addWebpackPreprocessorPlugin";
 import path from "path";
 
-const configFromEnv = dotenv.config({
+dotenv.config({
   path: path.resolve(__dirname, ".env.local")
 });
-
-dotenv.config();
 
 export default defineConfig({
   defaultCommandTimeout: 15000,
@@ -34,8 +32,7 @@ export default defineConfig({
   },
   env: {
     TAGS: "not @ignore",
-    windowMode: "desktop",
-    ...configFromEnv.parsed
+    windowMode: "desktop"
   },
   execTimeout: 15000,
   pageLoadTimeout: 20000,

--- a/e2e/cypress/test_module/cypress.config.ts
+++ b/e2e/cypress/test_module/cypress.config.ts
@@ -15,6 +15,14 @@ export default defineConfig({
   defaultCommandTimeout: 15000,
   e2e: {
     baseUrl: process.env.CLIENT_URL,
+    env: {
+      ROLE_ADMIN_EMAIL: process.env.ROLE_ADMIN_EMAIL,
+      ROLE_ADMIN_PASSWORD: process.env.ROLE_ADMIN_PASSWORD,
+      ROLE_MANAGER_EMAIL: process.env.ROLE_MANAGER_EMAIL,
+      ROLE_MANAGER_PASSWORD: process.env.ROLE_MANAGER_PASSWORD,
+      ROLE_USER_EMAIL: process.env.ROLE_USER_EMAIL,
+      ROLE_USER_PASSWORD: process.env.ROLE_USER_PASSWORD,
+    },
     async setupNodeEvents(on, config) {
       addWebpackPreprocessorPlugin(on, config);
       addTestCoveragePlugin(on, config);

--- a/e2e/cypress/test_module/cypress.config.ts
+++ b/e2e/cypress/test_module/cypress.config.ts
@@ -9,6 +9,8 @@ const configFromEnv = dotenv.config({
   path: path.resolve(__dirname, ".env.local")
 });
 
+dotenv.config();
+
 export default defineConfig({
   defaultCommandTimeout: 15000,
   e2e: {

--- a/e2e/cypress/test_module/cypress/features/dashboard-page/image-search-modal/image-search-modal.feature
+++ b/e2e/cypress/test_module/cypress/features/dashboard-page/image-search-modal/image-search-modal.feature
@@ -2,51 +2,42 @@ Feature: | Image search modal |
 
     Background: Before each
         Given I authenticate to the system under role ROLE_MANAGER
-        And I am on the Products page
-
-    Scenario: Manager can see 'Search on Pexels' button on 'Update product' page
-        Given I am on the Update Product page
-        Then I see the Search on Pexels button
-
-    Scenario: Manager can see 'Search on Pexels' button on 'Create a product' page
-        Given I am on the Create a Product page
-        Then I see the Search on Pexels button
+        When I click on the dashboard button
+        And I click on the 'products' tab
+        And I click on the 'first product update icon'
+        And I have opened the Image Search modal
 
     Scenario: Manager can search images by typing a word
-        Given I have opened the Image Search modal
-        When I type a word 'Phone'
-        Then I see eight images
-    
-    Scenario: Manager can search images by selecting suggested keywords
-        Given I have opened the Image Search modal
-        When I search images with keyword 'Laptop'
+        When I search images with typing keyword 'Smartphone'
         Then I see search results
 
-    Scenario: Loader is displayed during image search
-        Given I have opened the Image Search modal
-        When I search images by typing keyword 'Smartphone'
-        Then a loader is displayed
+    Scenario: Manager can search images by selecting suggested keywords
+        When I search images with suggested keyword 'Laptop'
+        Then I see search results
+
+     Scenario: Loader is displayed during image search
+        When I search images with typing keyword 'Smartphone'
+        Then the loader is visible
 
     Scenario: Manager selects an image from search results
-        Given I have opened the Image Search modal
-        When I search images by typing keyword 'Smartphone'
+        When I search images with typing keyword 'Smartphone'
         And I select an image from the search results
         Then the image is marked as selected
         And the Confirm button becomes enabled
 
     Scenario: Manager confirms selected image
-        Given an image is selected in the Image Search modal
-        When I confirm the image selection
+        When I search images with typing keyword 'Smartphone'
+        And I select an image from the search results
+        And I confirm the image selection
         Then the selected image is shown in the Image preview section
 
     Scenario: Manager can unselect image
-        Given I have opened the Image Search modal
         When I search images with typing keyword 'Smartphone'
         And I select an image from the search results
         And I deselect the image
         Then no image is selected
 
     Scenario: Manager can close modal
-        Given I have opened the Image Search modal
         When I click on the Close icon
         Then the modal is closed
+

--- a/e2e/cypress/test_module/cypress/features/dashboard-page/image-search-modal/image-search-modal.feature
+++ b/e2e/cypress/test_module/cypress/features/dashboard-page/image-search-modal/image-search-modal.feature
@@ -1,0 +1,52 @@
+Feature: | Image search modal |
+
+    Background: Before each
+        Given I authenticate to the system under role ROLE_MANAGER
+        And I am on the Products page
+
+    Scenario: Manager can see 'Search on Pexels' button on 'Update product' page
+        Given I am on the Update Product page
+        Then I see the Search on Pexels button
+
+    Scenario: Manager can see 'Search on Pexels' button on 'Create a product' page
+        Given I am on the Create a Product page
+        Then I see the Search on Pexels button
+
+    Scenario: Manager can search images by typing a word
+        Given I have opened the Image Search modal
+        When I type a word 'Phone'
+        Then I see eight images
+    
+    Scenario: Manager can search images by selecting suggested keywords
+        Given I have opened the Image Search modal
+        When I search images with keyword 'Laptop'
+        Then I see search results
+
+    Scenario: Loader is displayed during image search
+        Given I have opened the Image Search modal
+        When I search images by typing keyword 'Smartphone'
+        Then a loader is displayed
+
+    Scenario: Manager selects an image from search results
+        Given I have opened the Image Search modal
+        When I search images by typing keyword 'Smartphone'
+        And I select an image from the search results
+        Then the image is marked as selected
+        And the Confirm button becomes enabled
+
+    Scenario: Manager confirms selected image
+        Given an image is selected in the Image Search modal
+        When I confirm the image selection
+        Then the selected image is shown in the Image preview section
+
+    Scenario: Manager can unselect image
+        Given I have opened the Image Search modal
+        When I search images with typing keyword 'Smartphone'
+        And I select an image from the search results
+        And I deselect the image
+        Then no image is selected
+
+    Scenario: Manager can close modal
+        Given I have opened the Image Search modal
+        When I click on the Close icon
+        Then the modal is closed

--- a/e2e/cypress/test_module/cypress/features/dashboard-page/new-product/new-product.feature
+++ b/e2e/cypress/test_module/cypress/features/dashboard-page/new-product/new-product.feature
@@ -20,6 +20,10 @@ Feature: | New Product |
     And I click on the 'Create product' button
     Then I should receive a snackbar with message 'Product successfully created'
 
+  Scenario: Manager can open 'Search on Pexels' modal 
+    When I click on the 'Search on Pexels' button
+    Then I see Search on Pexels modal
+
   Scenario: Server error when manager creates a product
     Given Server returns 500 error when manager tries to create a product
     When I fill in the 'Image URL' field with "http://image.com"

--- a/e2e/cypress/test_module/cypress/features/dashboard-page/update-product/update-product.feature
+++ b/e2e/cypress/test_module/cypress/features/dashboard-page/update-product/update-product.feature
@@ -25,6 +25,10 @@ Feature: | Update Product |
         And I click on the 'Update product' button
         Then I should receive a snackbar with message 'Product successfully updated'
 
+    Scenario: Manager can open 'Search on Pexels' modal 
+        When I click on the 'Search on Pexels' button
+        Then I see Search on Pexels modal
+
     Scenario: Manager tries to update without changing anything
         And I click on the 'Update product' button
         Then I should not receive any snackbar message

--- a/e2e/cypress/test_module/cypress/support/step_definitions/image-search-modal.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/image-search-modal.ts
@@ -1,0 +1,82 @@
+/// <reference types="cypress" />
+
+import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
+
+When("I have opened the Image Search modal", () => {
+    cy.getById("product-form-image-search-button").click();
+});
+
+When("I search images with typing keyword 'Smartphone'", () => {
+    cy.get('[data-cy="image-search-input"]')
+        .should("be.visible")
+        .clear()
+        .type("Smartphone");
+});
+
+Then("I see search results", () => {
+    cy.getById("image-search-results")
+        .children()
+        .should("have.length", 8);
+});
+
+When("I search images with suggested keyword 'Laptop'", () => {
+    cy.get('[data-cy="image-search-input"]')
+        .should("be.visible")
+        .clear();
+    cy.getById("suggested-keywords").contains("Laptop").click();
+});
+
+Then("the loader is visible", () => {
+    cy.get('[data-testid="image-search-loader"]').should("be.visible");
+});
+
+When("I select an image from the search results", () => {
+    cy.getById("image-search-results")
+        .children()
+        .first()
+        .click();
+});
+
+Then("the image is marked as selected", () => {
+    cy.getById("image-search-results")
+        .children()
+        .first()
+        .should("have.attr", "data-cy", "selected-image");
+});
+
+Then("the Confirm button becomes enabled", () => {
+    cy.getById("image-search-confirm-button").should("not.be.disabled");
+});
+
+When("I confirm the image selection", () => {
+    cy.getById("image-search-confirm-button").click();
+});
+
+Then("the selected image is shown in the Image preview section", () => {
+    cy.get('[data-testid="product-form-image-preview"]')
+    .should("be.visible")
+    .and("have.prop", "tagName")
+    .should("eq", "IMG");
+});
+
+When("I deselect the image", () => {
+    cy.getById("image-search-results")
+        .children()
+        .first()
+        .click();
+});
+
+Then("no image is selected", () => {
+    cy.getById("image-search-results")
+        .children()
+        .first()
+        .should("not.have.attr", "data-cy", "selected-image");
+});
+
+When("I click on the Close icon", () => {
+    cy.get('[data-testid="close-icon"]').click();
+});
+
+Then("the modal is closed", () => {
+    cy.getById("image-search-modal").should("not.exist");
+});

--- a/e2e/cypress/test_module/cypress/support/step_definitions/product-form.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/product-form.steps.ts
@@ -62,6 +62,14 @@ When("I click on the 'Update product' button", () => {
   cy.getById("update-product-form-button").click();
 });
 
+When("I click on the 'Search on Pexels' button", () => {
+  cy.getById("product-form-image-search-button").click();
+});
+
+Then("I see Search on Pexels modal", () => {
+  cy.getById("image-search-modal").should("exist").and("be.visible");
+});
+
 When("Server returns 500 error when manager tries to update a product", () => {
   cy.intercept(httpMethod.patch, /\/v1\/management\/products/, {
     statusCode: httpStatusCode.internalServerError


### PR DESCRIPTION
Created scenarios for `image-search-modal` feature:
- Manager can search images by typing a word
- Manager can search images by selecting suggested keywords
- Loader is displayed during image search
- Manager selects an image from search results
- Manager confirms selected image
- Manager can unselect image
- Manager can close modal

Created scenarios for `new-product` and `update-product` features:
- Manager can open 'Search on Pexels' modal 

Added dotenv support

<img width="508" height="367" alt="image" src="https://github.com/user-attachments/assets/00590b32-9272-4db7-a74c-3b2902afbc65" />

<img width="455" height="176" alt="image" src="https://github.com/user-attachments/assets/ac3eb8b3-bdb0-4284-af8e-843f22c1c2ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the Image Search modal (search, suggested keywords, loader, select/deselect, confirm, preview, close) and integrated scenarios into product create/update flows.

* **Chores**
  * Updated E2E environment handling to map role credentials into test env without exposing parsed .env values to top-level env.
  * Added stable test selectors to support reliable UI tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->