### PR TITLE
[GS2-249] Added Cypress E2E for reserved label

### DIFF
--- a/e2e/cypress/test_module/cypress/features/user-profile/my-reservations/my-reservations-page.feature
+++ b/e2e/cypress/test_module/cypress/features/user-profile/my-reservations/my-reservations-page.feature
@@ -34,3 +34,8 @@ Feature: | My Reservations page |
         When I am on the Product Details page
         And I try to add one more of the same product
         Then I should see a snackbar with the message 'You can reserve up to 5 items.'
+
+    Scenario: User see label for reserved product on Product card on My Reservations page
+        Given My reservations contain 1 product
+        When I navigated to the My Reservations page
+        Then I see this product with Reserved label

--- a/e2e/cypress/test_module/cypress/support/step_definitions/my-reservations.steps.ts
+++ b/e2e/cypress/test_module/cypress/support/step_definitions/my-reservations.steps.ts
@@ -147,3 +147,8 @@ When("I try to add one more of the same product", () => {
 
     cy.getById("reserve-product-button").click();
 });
+
+Then("I see this product with Reserved label", () => {
+    cy.getById("product-card").should("be.visible");
+    cy.get('[data-testid="reserved-label"]').should("be.visible");
+});


### PR DESCRIPTION
Created scenario for Reserved label
<img width="606" height="64" alt="image" src="https://github.com/user-attachments/assets/efa3984a-1499-4300-8986-cce3cd1e14c4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added test scenario to verify that reserved products display a "Reserved" label on product cards in the My Reservations page
* Added test step definition to validate product card and reserved label visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->