### PR TITLE
[GS2-264] Visualized out of stock in product details

### DIFF
--- a/code/src/pages/product-details/components/buy-now-button/BuyNowButton.tsx
+++ b/code/src/pages/product-details/components/buy-now-button/BuyNowButton.tsx
@@ -6,9 +6,10 @@ import { Product } from "@/types/product.types";
 
 type BuyNowButtonProps = {
   productWithId: Omit<Product, "status">;
+  disabled?: boolean;
 };
 
-const BuyNowButton = ({ productWithId }: BuyNowButtonProps) => {
+const BuyNowButton = ({ productWithId, disabled = false }: BuyNowButtonProps) => {
   const {
     isProductInCart,
     addToCartOrOpenDrawer,
@@ -26,13 +27,13 @@ const BuyNowButton = ({ productWithId }: BuyNowButtonProps) => {
     translationKey = "productDetailsPage.addToCartButton";
   }
 
-  const isDisabled = isAddingToCart || isCartLoading;
+  const isButtonLoading = isAddingToCart || isCartLoading;
 
   return (
     <AppButton
       onClick={addToCartOrOpenDrawer}
-      disabled={isDisabled}
-      isLoading={isDisabled}
+      disabled={disabled || isButtonLoading}
+      isLoading={isButtonLoading}
     >
       <AppTypography translationKey={translationKey} />
     </AppButton>

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.test.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.test.tsx
@@ -235,7 +235,6 @@ describe("ProductDetailsContainer", () => {
         );
     });
 
-
     test("renders delivery methods correctly", () => {
         renderAndMock({ data: mockProduct });
 
@@ -409,5 +408,15 @@ describe("ProductDetailsContainer", () => {
 
         await userEvent.click(screen.getByTestId("FavoriteBorderIcon"));
         expect(mockOpenModal).toHaveBeenCalled();
+    });
+
+    test("renders out of stock when product is ended", () => {
+        renderAndMock({
+            data: { ...mockProduct, status: "ENDED" }
+        });
+
+        expect(
+            screen.getByText("productDetailsPage.outOfStock")
+        ).toBeInTheDocument();
     });
 });

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.test.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.test.tsx
@@ -13,7 +13,7 @@ import formatPrice from "@/utils/format-price/formatPrice";
 import renderWithProviders from "@/utils/render-with-providers/renderWithProviders";
 import useToggleFavorite from "@/hooks/use-toggle-favorite/useToggleFavorite";
 import { useUserRoleSelector, useIsAuthSelector } from "@/store/slices/userSlice";
-import { ROLES } from "@/constants/common";
+import { ROLES, PRODUCT_STATUS } from "@/constants/common";
 
 type MockProduct = Product & { quantity: number };
 
@@ -230,10 +230,11 @@ describe("ProductDetailsContainer", () => {
         expect(buyNowButton).toBeInTheDocument();
 
         expect(BuyNowButton).toHaveBeenCalledWith(
-            { productWithId: { ...mockProduct, id: productId } },
+            { productWithId: { ...mockProduct, id: productId }, disabled: false },
             {}
         );
     });
+
 
     test("renders delivery methods correctly", () => {
         renderAndMock({ data: mockProduct });
@@ -254,7 +255,7 @@ describe("ProductDetailsContainer", () => {
     });
 
     test("does not render stock typography when quantity is 0", () => {
-        renderAndMock({ data: { ...mockProduct, quantity: 0 } });
+        renderAndMock({ data: { ...mockProduct, status: PRODUCT_STATUS.ENDED } });
 
         const inStockTypography = screen.queryByText("productDetailsPage.inStock");
         expect(inStockTypography).not.toBeInTheDocument();
@@ -410,4 +411,3 @@ describe("ProductDetailsContainer", () => {
         expect(mockOpenModal).toHaveBeenCalled();
     });
 });
-

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.test.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.test.tsx
@@ -410,7 +410,7 @@ describe("ProductDetailsContainer", () => {
         expect(mockOpenModal).toHaveBeenCalled();
     });
 
-    test("renders out of stock when product is ended", () => {
+    test("should render out of stock when product is ended", () => {
         renderAndMock({
             data: { ...mockProduct, status: "ENDED" }
         });
@@ -418,5 +418,14 @@ describe("ProductDetailsContainer", () => {
         expect(
             screen.getByText("productDetailsPage.outOfStock")
         ).toBeInTheDocument();
+    });
+
+    test("should disable favorite button when status is ENDED", () => {
+        renderAndMock({
+            data: { ...mockProduct, status: "ENDED" }
+        });
+
+        const favoriteButton = screen.getByTestId("favorite-button");
+        expect(favoriteButton).toBeDisabled();
     });
 });

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
@@ -203,7 +203,7 @@ const ProductDetailsContainer = ({
               {isUserOrGuest && (
                 <AppBox className="product-details__buy-favorite-buttons">
                   <AppIconButton
-                    data-cy="favorite-button"
+                    data-testid="favorite-button"
                     onClick={handleFavoriteClick}
                     className={cn(
                       "product-details__favorite-button",
@@ -223,7 +223,8 @@ const ProductDetailsContainer = ({
                   />
                   <BuyNowButton
                     productWithId={productWithId}
-                    disabled={isEnded} />
+                    disabled={isEnded}
+                  />
                 </AppBox>
               )}
             </AppBox>

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
@@ -26,6 +26,7 @@ import { useGetUserProductByIdQuery } from "@/store/api/productsApi";
 import getCategoryFromTags from "@/utils/get-category-from-tags/getCategoryFromTags";
 import isErrorWithStatus from "@/utils/is-error-with-status/isErrorWithStatus";
 import cn from "@/utils/cn/cn";
+import { getProductStatus } from "@/utils/get-product-status/getProductStatus";
 import { Product } from "@/types/product.types";
 import { useModalContext } from "@/context/modal/ModalContext";
 import { useIsAuthSelector, useUserRoleSelector } from "@/store/slices/userSlice";
@@ -55,7 +56,9 @@ const ProductDetailsContainer = ({
     productId,
     lang: locale
   });
-  
+
+  const { isEnded } = getProductStatus(product);
+
   const isAuthenticated = useIsAuthSelector();
   const { openModal } = useModalContext();
   const userRole = useUserRoleSelector();
@@ -115,14 +118,17 @@ const ProductDetailsContainer = ({
     }
   );
 
-  const inStockTypography = product.quantity > 0 && (
+  const stockTranslationKey = isEnded
+    ? "productDetailsPage.outOfStock"
+    : "productDetailsPage.inStock";
+
+  const inStockTypography =
     <AppTypography
       className="product-details__in-stock"
       fontWeight="extra-bold"
       variant="caption"
-      translationKey="productDetailsPage.inStock"
+      translationKey={stockTranslationKey}
     />
-  );
 
   const productWithId = { ...product, id: productId };
 
@@ -157,7 +163,7 @@ const ProductDetailsContainer = ({
       openModal(<AuthModal />);
       return;
     }
-    
+
     toggle(productId);
   };
 
@@ -194,7 +200,7 @@ const ProductDetailsContainer = ({
                 discountedPriceSize="h3"
                 discountedPriceWeight="bold"
               />
-              { isUserOrGuest && (
+              {isUserOrGuest && (
                 <AppBox className="product-details__buy-favorite-buttons">
                   <AppIconButton
                     data-cy="favorite-button"
@@ -203,15 +209,21 @@ const ProductDetailsContainer = ({
                       "product-details__favorite-button",
                       isProductFavorite && "product-details__favorite-button--active"
                     )}
+                    disabled={isEnded}
                   >
-                  {isProductFavorite ? (
-                    <FavoriteIcon fontSize="medium" />
-                  ) : (
-                    <FavoriteBorderIcon fontSize="medium" />
-                  )}
+                    {isProductFavorite ? (
+                      <FavoriteIcon fontSize="medium" />
+                    ) : (
+                      <FavoriteBorderIcon fontSize="medium" />
+                    )}
                   </AppIconButton>
-                  <ReserveButtonContainer productId={productId} />
-                  <BuyNowButton productWithId={productWithId} />
+                  <ReserveButtonContainer
+                    productId={productId}
+                    disabled={isEnded}
+                  />
+                  <BuyNowButton
+                    productWithId={productWithId}
+                    disabled={isEnded} />
                 </AppBox>
               )}
             </AppBox>

--- a/code/src/pages/product-details/components/reserve-button-container/ReserveButtonContainer.tsx
+++ b/code/src/pages/product-details/components/reserve-button-container/ReserveButtonContainer.tsx
@@ -12,7 +12,8 @@ import { useModalContext } from "@/context/modal/ModalContext";
 import useAddToReservations from "@/hooks/use-add-to-reservations/useAddToReservations";
 
 export const ReserveButtonContainer = ({
-    productId
+    productId,
+    disabled = false
 }: ReserveButtonContainerProps) => {
     const isAuthenticated = useIsAuthSelector();
     const userRole = useUserRoleSelector();
@@ -53,6 +54,7 @@ export const ReserveButtonContainer = ({
         <ReserveButton
             isReserved={isReserved}
             isLoading={isLoading}
+            isDisabled={disabled}
             onToggle={handleToggle}
         />
     );

--- a/code/src/pages/product-details/components/reserve-button-container/ReserveButtonContainer.types.ts
+++ b/code/src/pages/product-details/components/reserve-button-container/ReserveButtonContainer.types.ts
@@ -1,3 +1,4 @@
 export type ReserveButtonContainerProps = {
     productId: string;
+    disabled?: boolean;
 };

--- a/code/src/pages/product-details/components/reserve-button/ReserveButton.tsx
+++ b/code/src/pages/product-details/components/reserve-button/ReserveButton.tsx
@@ -5,18 +5,20 @@ import AppLoader from "@/components/app-loader/AppLoader";
 type ReserveButtonProps = {
   isReserved: boolean;
   isLoading?: boolean;
+  isDisabled?: boolean;
   onToggle: () => void;
 };
 
 const ReserveButton = ({
   isReserved,
   isLoading,
+  isDisabled = false,
   onToggle,
 }: ReserveButtonProps) => {
   return (
     <AppButton
       onClick={onToggle}
-      disabled={isLoading}
+      disabled={isDisabled || isLoading}
       className="reserve-button"
       data-cy="reserve-product-button"
     >

--- a/code/src/pages/product-details/messages/en.json
+++ b/code/src/pages/product-details/messages/en.json
@@ -7,6 +7,7 @@
   "productDetailsPage.reserveButton": "Reserve",
   "productDetailsPage.reservedButton": "Reserved",
   "productDetailsPage.inStock": "In stock",
+  "productDetailsPage.outOfStock": "Out of stock",
   "productDetailsPage.deliveryMethodsCaption": "Delivery methods",
   "productDetailsPage.descriptionCaption": "Description",
   "productDetailsPage.loadErrorMessage": "We encountered a problem while loading the product details.\nPlease try again later."

--- a/code/src/pages/product-details/messages/uk.json
+++ b/code/src/pages/product-details/messages/uk.json
@@ -7,6 +7,7 @@
   "productDetailsPage.reserveButton": "Зарезервувати",
   "productDetailsPage.reservedButton": "Зарезервовано",
   "productDetailsPage.inStock": "На складі",
+  "productDetailsPage.outOfStock": "Немає в наявності",
   "productDetailsPage.deliveryMethodsCaption": "Методи доставки",
   "productDetailsPage.descriptionCaption": "Опис",
   "productDetailsPage.loadErrorMessage": "Під час завантаження інформації про товар виникла проблема.\nБудь ласка, спробуйте пізніше."


### PR DESCRIPTION
Added `isEnded` logic to the button components on the `Product details` page.

If product has status **`ENDED`** so 
- `Favorite` button is disabled
- `Reserved` button is disabled
- `Buy now` button is disabled
- Added `Out of stock` text
<img width="1568" height="691" alt="image" src="https://github.com/user-attachments/assets/d458c9f3-6480-4c04-b5b5-26b8fed4a51d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disabled purchase actions (Buy Now, Reserve) when a product listing ends.
  * Updated stock status display to show "Out of stock" when product has ended.
  * Disabled favorite button for ended products.

* **Documentation**
  * Added "Out of stock" translation in English and Ukrainian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->