### PR TITLE
[GS2-263] Visualized Out of stock in search bar

### DIFF
--- a/code/src/components/product-card/ProductCard.tsx
+++ b/code/src/components/product-card/ProductCard.tsx
@@ -36,10 +36,10 @@ const ProductCard = ({ product, isViewHistory = false, wishlist = [] }: ProductC
   const { toggle, isFavorite } = useToggleFavorite(wishlist);
   const { isReserved } = useIsProductReserved(product.id);
 
-  const { isEnded, labelKey } = getProductStatus(product);
-
   const { id, name, image, price, description, percentageOfTotalOrders } =
     product;
+
+  const { isEnded, labelKey } = getProductStatus(product.status);
 
   const [imgSrc, setImgSrc] = useState(image);
 

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -50,7 +50,7 @@ const SaleProductCard = ({
 
   const { isReserved } = useIsProductReserved(product.id);
 
-  const { isEnded, labelKey } = getProductStatus(product);
+  const { isEnded, labelKey } = getProductStatus(product.status);
 
   const roundedPercentage = Math.round(percentageOfTotalOrders || 0);
 

--- a/code/src/components/product-status-label/ProductStatusLabel.tsx
+++ b/code/src/components/product-status-label/ProductStatusLabel.tsx
@@ -1,17 +1,20 @@
 import AppBox from "@/components/app-box/AppBox";
 import AppTypography from "@/components/app-typography/AppTypography";
-
 import { TRANSLATION_KEYS } from "@/components/product-status-label/ProductStatusLabel.constants";
 import { ProductStatusLabelProps } from "@/components/product-status-label/ProductStatusLabel.types";
 
+import cn from "@/utils/cn/cn";
+
 import "@/components/product-status-label/ProductStatusLabel.scss";
+
 
 const ProductStatusLabel = ({
   status,
+  className
 }: ProductStatusLabelProps) => {
 
   return (
-    <AppBox className="spa-product-status-label">
+    <AppBox className={cn("spa-product-status-label", className)}>
       <AppTypography
         translationKey={TRANSLATION_KEYS[status]}
         variant="caption-small"

--- a/code/src/components/product-status-label/ProductStatusLabel.types.ts
+++ b/code/src/components/product-status-label/ProductStatusLabel.types.ts
@@ -2,4 +2,5 @@ import { PRODUCT_STATUS_LABELS } from "@/components/product-status-label/Product
 
 export type ProductStatusLabelProps = {
     status: (typeof PRODUCT_STATUS_LABELS)[keyof typeof PRODUCT_STATUS_LABELS];
+    className?: string;
 };

--- a/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.scss
+++ b/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.scss
@@ -76,5 +76,9 @@
       height: spacing(2);
       align-items: center;
     }
+
+    &-name-inactive {
+      color: var(--color-disabled);
+    }
   }
 }

--- a/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.scss
+++ b/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.scss
@@ -77,6 +77,13 @@
       align-items: center;
     }
 
+    &-inactive {
+      &:hover {
+        background-color: transparent;
+
+      }
+    }
+
     &-name-inactive {
       color: var(--color-disabled);
     }

--- a/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.scss
+++ b/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.scss
@@ -57,6 +57,12 @@
 
     &-image {
       @include box(40px);
+
+      &-grayscale {
+        filter: grayscale(100%);
+        opacity: 0.6;
+        transition: filter 0.2s ease, opacity 0.2s ease;
+      }
     }
 
     &-label-name-container {

--- a/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.scss
+++ b/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.scss
@@ -80,7 +80,6 @@
     &-inactive {
       &:hover {
         background-color: transparent;
-
       }
     }
 

--- a/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.test.tsx
+++ b/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.test.tsx
@@ -17,8 +17,8 @@ jest.mock("@/hooks/use-is-product-reserved/useIsProductReserved");
 const mockUseIsProductReserved = useIsProductReserved as jest.MockedFunction<typeof useIsProductReserved>;
 
 const searchResults: ProductFromSearch[] = [
-  { id: "1", name: "Product 1", image: "image1.png" },
-  { id: "2", name: "Product 2", image: "image2.png" }
+  { id: "1", name: "Product 1", image: "image1.png", status: "AVAILABLE" },
+  { id: "2", name: "Product 2", image: "image2.png", status: "AVAILABLE" }
 ];
 
 const reservedProductsMock: GetMyReservationsResponse = [

--- a/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.test.tsx
+++ b/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.test.tsx
@@ -151,4 +151,17 @@ describe("HeaderSearchInputDropdown", () => {
       expect(reservedLabel).not.toBeInTheDocument();
     });
   });
+
+  describe("Out of stock", () => {
+    const outOfStockProduct: ProductFromSearch[] = [
+      { id: "3", name: "Product 3", image: "image3.png", status: "ENDED" }
+    ];
+
+    test("should render out of stock label for ended product", () => {
+      renderComponent({ searchResults: outOfStockProduct, totalElements: 1 });
+
+      const statusLabel = screen.getByTestId("product-status-label");
+      expect(statusLabel).toBeInTheDocument();
+    });
+  });
 });

--- a/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.tsx
+++ b/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.tsx
@@ -106,7 +106,9 @@ const HeaderSearchInputDropdown = ({
           return (
             <AppMenuItem
               key={id}
-              className="search-input-dropdown__item"
+              className={cn("search-input-dropdown__item",
+                isEnded && "search-input-dropdown__item-inactive"
+              )}
               onClick={handleCloseDropdown}
               ref={index === searchResults.length - 1 ? lastItemRef : undefined}
             >

--- a/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.tsx
+++ b/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.tsx
@@ -124,12 +124,28 @@ const HeaderSearchInputDropdown = ({
                   alt={name}
                 />
                 <AppBox className="search-input-dropdown__item-label-name-container">
-                  {isReserved && <ReservedLabel className="search-input-dropdown__item-label" data-testid="reserved-label" />}
-                  {labelKey && <ProductStatusLabel status={labelKey} />}
-                  <AppTypography variant="caption-small">{name}</AppTypography>
+                  {isReserved &&
+                    <ReservedLabel
+                      className="search-input-dropdown__item-label"
+                      data-testid="reserved-label"
+                    />
+                  }
+                  {labelKey &&
+                    <ProductStatusLabel
+                      status={labelKey}
+                      className="search-input-dropdown__item-label"
+                    />
+                  }
+                  <AppTypography
+                    variant="caption-small"
+                    className={cn("search-input-dropdown__item-name",
+                      isEnded && "search-input-dropdown__item-name-inactive"
+                    )}>
+                    {name}
+                  </AppTypography>
                 </AppBox>
               </AppLink>
-            </AppMenuItem>
+            </AppMenuItem >
           )
         })}
       </>

--- a/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.tsx
+++ b/code/src/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.tsx
@@ -4,6 +4,7 @@ import AppMenuItem from "@/components/app-menu-item/AppMenuItem";
 import AppSkeleton from "@/components/app-skeleton/AppSkeleton";
 import AppTypography from "@/components/app-typography/AppTypography";
 import ReservedLabel from "@/components/reserved-label/ReservedLabel";
+import ProductStatusLabel from "@/components/product-status-label/ProductStatusLabel";
 
 import noResultsImage from "@/assets/images/search/no-results.png";
 import routePaths from "@/constants/routes";
@@ -11,6 +12,8 @@ import useInfiniteScroll from "@/hooks/use-infinite-scroll/useInfiniteScroll";
 import { useIsProductReserved } from "@/hooks/use-is-product-reserved/useIsProductReserved";
 import { ProductFromSearch } from "@/types/product.types";
 import repeatComponent from "@/utils/repeat-component/repeatComponent";
+import { getProductStatus } from "@/utils/get-product-status/getProductStatus";
+import cn from "@/utils/cn/cn";
 
 import "@/layouts/header/components/header-search-input-dropdown/HeaderSearchInputDropdown.scss";
 
@@ -95,8 +98,10 @@ const HeaderSearchInputDropdown = ({
     content = (
       <>
         {searchResultsLabel}
-        {searchResults.map(({ id, name, image }, index) => {
+        {searchResults.map(({ id, name, image, status }, index) => {
           const isReserved = reservedProducts.some(p => p.id === id);
+
+          const { isEnded, labelKey } = getProductStatus(status);
 
           return (
             <AppMenuItem
@@ -110,13 +115,17 @@ const HeaderSearchInputDropdown = ({
                 to={routePaths.productDetails.path(id)}
               >
                 <AppBox
-                  className="search-input-dropdown__item-image"
+                  className={cn(
+                    "search-input-dropdown__item-image",
+                    isEnded && "search-input-dropdown__item-image-grayscale"
+                  )}
                   component="img"
                   src={image}
                   alt={name}
                 />
                 <AppBox className="search-input-dropdown__item-label-name-container">
                   {isReserved && <ReservedLabel className="search-input-dropdown__item-label" data-testid="reserved-label" />}
+                  {labelKey && <ProductStatusLabel status={labelKey} />}
                   <AppTypography variant="caption-small">{name}</AppTypography>
                 </AppBox>
               </AppLink>

--- a/code/src/types/product.types.ts
+++ b/code/src/types/product.types.ts
@@ -35,7 +35,7 @@ export type ManagerProduct = {
   priceWithDiscount: number | null;
 };
 
-export type ProductFromSearch = Pick<Product, "id" | "image" | "name">;
+export type ProductFromSearch = Pick<Product, "id" | "image" | "name" | "status">;
 
 export type GetUserProductsResponse = {
   minProductPrice: number;

--- a/code/src/utils/get-product-status/getProductStatus.ts
+++ b/code/src/utils/get-product-status/getProductStatus.ts
@@ -5,9 +5,9 @@ import { Product } from "@/types/product.types";
 import { GetProductStatusResult } from "@/utils/get-product-status/getProductStatus.types";
 
 export const getProductStatus = (
-  product?: Product
+  status: Product["status"]
 ): GetProductStatusResult => {
-  const isEnded = product?.status === PRODUCT_STATUS.ENDED;
+  const isEnded = status === PRODUCT_STATUS.ENDED;
 
   return {
     isEnded,


### PR DESCRIPTION
Added `isEnded` logic for product in search results.

If product has status **`ENDED`**  so
- Displayed image with a gray card background (Added grayscale).
- Displayed description with a gray card background.
- No color highlights or saturation (no hover).
- Added an "Out of Stock" label.

<img width="344" height="189" alt="image" src="https://github.com/user-attachments/assets/a8922efd-29ad-472c-a17b-5e02c0b2274d" />

- Changed `ProductFromSearch` type
- Edited `getProductStatus`
- Fixed test, added new one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product status indicators now display inline in search results, including a visible status label next to reserved labels.
  * Ended/out-of-stock items render with grayscale and inactive typography for clear distinction.

* **Style**
  * Search dropdown item styling updated to support inactive visuals and transitions.

* **Tests**
  * Added tests covering product status display in search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->