### PR TITLE
[GS2-281] Integrated reservation timer

### DIFF
--- a/code/src/components/circular-countdown/CircularCountdown.scss
+++ b/code/src/components/circular-countdown/CircularCountdown.scss
@@ -3,7 +3,7 @@
 .circular-countdown {
     display: block;
     position: relative;
-    background-color: transparent;
+    background-color: $white;
     border-radius: 50%;
     overflow: hidden;
     border: 1px solid #e0e0e0;

--- a/code/src/components/product-card/ProductCard.scss
+++ b/code/src/components/product-card/ProductCard.scss
@@ -10,19 +10,20 @@
   overflow: hidden;
 
   &__labels-timer {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    padding-right: spacing(2);
-  }
-
-  &__labels {
     position: absolute;
     top: spacing(2);
     left: spacing(2);
     right: spacing(2);
     display: flex;
-    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    z-index: 2;
+  }
+
+  &__labels {
+    display: flex;
+    align-items: flex-start;
     gap: spacing(1);
     z-index: 1;
   }

--- a/code/src/components/product-card/ProductCard.scss
+++ b/code/src/components/product-card/ProductCard.scss
@@ -9,6 +9,13 @@
   position: relative;
   overflow: hidden;
 
+  &__labels-timer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding-right: spacing(2);
+  }
+
   &__labels {
     position: absolute;
     top: spacing(2);

--- a/code/src/components/product-card/ProductCard.tsx
+++ b/code/src/components/product-card/ProductCard.tsx
@@ -7,6 +7,7 @@ import AppTypography from "@/components/app-typography/AppTypography";
 import { ProductCardProps } from "@/components/product-card/ProductCard.types";
 import ReservedLabel from "@/components/reserved-label/ReservedLabel";
 import ProductStatusLabel from "@/components/product-status-label/ProductStatusLabel";
+import CircularCountdown from "@/components/circular-countdown/CircularCountdown";
 
 import AuthModal from "@/containers/modals/auth/AuthModal";
 
@@ -30,7 +31,12 @@ import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import "@/components/product-card/ProductCard.scss";
 
-const ProductCard = ({ product, isViewHistory = false, wishlist = [] }: ProductCardProps) => {
+const ProductCard = ({
+  product,
+  isViewHistory = false,
+  wishlist = [],
+  reservedAt,
+}: ProductCardProps) => {
   const { isProductInCart, addToCartOrOpenDrawer } =
     useAddToCartOrOpenDrawer(product);
   const { toggle, isFavorite } = useToggleFavorite(wishlist);
@@ -78,9 +84,14 @@ const ProductCard = ({ product, isViewHistory = false, wishlist = [] }: ProductC
       className="spa-product-card"
       data-cy="product-card"
     >
-      <AppBox className="spa-product-card__labels">
-        {isReserved && <ReservedLabel />}
-        {labelKey && <ProductStatusLabel status={labelKey} />}
+      <AppBox className="spa-product-card__labels-timer">
+        <AppBox className="spa-product-card__labels">
+          {isReserved && <ReservedLabel />}
+          {labelKey && <ProductStatusLabel status={labelKey} />}
+        </AppBox>
+        {reservedAt && (
+          <CircularCountdown reservedAt={reservedAt} size={60} />
+        )}
       </AppBox>
       <AppLink
         className="spa-product-card__link-wrapper"

--- a/code/src/components/product-card/ProductCard.types.ts
+++ b/code/src/components/product-card/ProductCard.types.ts
@@ -4,4 +4,5 @@ export type ProductCardProps = {
   product: Product;
   isViewHistory?: boolean;
   wishlist?: Product[];
+  reservedAt?: string;
 };

--- a/code/src/components/product-sale-card/SaleProductCard.scss
+++ b/code/src/components/product-sale-card/SaleProductCard.scss
@@ -9,12 +9,13 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    align-items: flex-start;
     z-index: 2;
   }
 
   &__labels {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: spacing(1);
     z-index: 1;
   }

--- a/code/src/components/product-sale-card/SaleProductCard.scss
+++ b/code/src/components/product-sale-card/SaleProductCard.scss
@@ -1,11 +1,18 @@
 @import "@design-system";
 
 .spa-sale-product-card {
-  &__labels {
+  &__labels-timer {
     position: absolute;
     top: spacing(2);
     left: spacing(2);
     right: spacing(2);
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    z-index: 2;
+  }
+
+  &__labels {
     display: flex;
     align-items: center;
     gap: spacing(1);

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -10,6 +10,7 @@ import AppTypography from "@/components/app-typography/AppTypography";
 import { ProductCardProps } from "@/components/product-card/ProductCard.types";
 import ReservedLabel from "@/components/reserved-label/ReservedLabel";
 import ProductStatusLabel from "@/components/product-status-label/ProductStatusLabel";
+import CircularCountdown from "../circular-countdown/CircularCountdown";
 
 import AuthModal from "@/containers/modals/auth/AuthModal";
 
@@ -32,7 +33,8 @@ import "@/components/product-sale-card/SaleProductCard.scss";
 const SaleProductCard = ({
   product,
   isViewHistory = false,
-  wishlist = []
+  wishlist = [],
+  reservedAt,
 }: ProductCardProps) => {
   const { isProductInCart, addToCartOrOpenDrawer } =
     useAddToCartOrOpenDrawer(product);
@@ -100,6 +102,9 @@ const SaleProductCard = ({
         {isReserved && <ReservedLabel />}
         {labelKey && <ProductStatusLabel status={labelKey} />}
       </AppBox>
+      {reservedAt && (
+        <CircularCountdown reservedAt={reservedAt} size={60} />
+      )}
       <AppLink
         className="spa-product-card__link-wrapper"
         to={routePaths.productDetails.path(id)}

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -92,19 +92,21 @@ const SaleProductCard = ({
       className="spa-product-card spa-sale-product-card"
       data-cy="product-card"
     >
-      <AppBox className="spa-sale-product-card__labels">
-        <AppBox
-          className="spa-sale-product-card__label"
-          data-testid="discount-label"
-        >
-          -{discount}%
+      <AppBox className="spa-product-card__labels-timer">
+        <AppBox className="spa-sale-product-card__labels">
+          <AppBox
+            className="spa-sale-product-card__label"
+            data-testid="discount-label"
+          >
+            -{discount}%
+          </AppBox>
+          {isReserved && <ReservedLabel />}
+          {labelKey && <ProductStatusLabel status={labelKey} />}
         </AppBox>
-        {isReserved && <ReservedLabel />}
-        {labelKey && <ProductStatusLabel status={labelKey} />}
+        {reservedAt && (
+          <CircularCountdown reservedAt={reservedAt} size={60} />
+        )}
       </AppBox>
-      {reservedAt && (
-        <CircularCountdown reservedAt={reservedAt} size={60} />
-      )}
       <AppLink
         className="spa-product-card__link-wrapper"
         to={routePaths.productDetails.path(id)}
@@ -209,7 +211,7 @@ const SaleProductCard = ({
           </AppBox>
         )}
       </AppBox>
-    </AppBox>
+    </AppBox >
   );
 };
 

--- a/code/src/components/product-sale-card/SaleProductCard.tsx
+++ b/code/src/components/product-sale-card/SaleProductCard.tsx
@@ -92,7 +92,7 @@ const SaleProductCard = ({
       className="spa-product-card spa-sale-product-card"
       data-cy="product-card"
     >
-      <AppBox className="spa-product-card__labels-timer">
+      <AppBox className="spa-sale-product-card__labels-timer">
         <AppBox className="spa-sale-product-card__labels">
           <AppBox
             className="spa-sale-product-card__label"
@@ -211,7 +211,7 @@ const SaleProductCard = ({
           </AppBox>
         )}
       </AppBox>
-    </AppBox >
+    </AppBox>
   );
 };
 

--- a/code/src/constants/requests.ts
+++ b/code/src/constants/requests.ts
@@ -131,6 +131,7 @@ export const URLS = {
     put: ({ productId }: { productId: string }) =>
       `/v1/my-reservations/${productId}`,
     delete: ({ productId }: { productId: string }) =>
-      `/v1/my-reservations/${productId}`
+      `/v1/my-reservations/${productId}`,
+    getMyReservationsMetadata: "/v1/my-reservations/metadata"
   },
 } as const;

--- a/code/src/containers/products-container/ProductsContainer.tsx
+++ b/code/src/containers/products-container/ProductsContainer.tsx
@@ -25,6 +25,7 @@ const ProductsContainer = ({
   errorMessage = "errors.somethingWentWrong",
   isViewHistory = false,
   wishlist = [],
+  reservationsMetadata,
 }: ProductsContainerProps) => {
   const { isLoading: isCartLoading } = useGetCart();
   const isAuthLoading = useIsAuthLoadingSelector();
@@ -45,6 +46,10 @@ const ProductsContainer = ({
   }
 
   const productCards = products.map((product: Product) => {
+    const reservation = reservationsMetadata?.find(
+      r => r.id === product.id
+    );
+
     const productCard =
       product.priceWithDiscount && product.discount ? (
         <SaleProductCard
@@ -52,6 +57,7 @@ const ProductsContainer = ({
           product={product}
           isViewHistory={isViewHistory}
           wishlist={wishlist}
+          reservedAt={reservation?.reservedAt}
         />
       ) : (
         <ProductCard
@@ -59,6 +65,7 @@ const ProductsContainer = ({
           product={product}
           isViewHistory={isViewHistory}
           wishlist={wishlist}
+          reservedAt={reservation?.reservedAt}
         />
       );
 

--- a/code/src/containers/products-container/ProductsContainer.types.ts
+++ b/code/src/containers/products-container/ProductsContainer.types.ts
@@ -1,4 +1,4 @@
-import { Product } from "@/types/product.types";
+import { Product, ReservationMetadata } from "@/types/product.types";
 
 export type ProductsContainerProps = {
   products: Product[];
@@ -10,6 +10,7 @@ export type ProductsContainerProps = {
   maxColumns?: number;
   isViewHistory?: boolean;
   wishlist?: Product[];
+  reservationsMetadata?: ReservationMetadata[];
 };
 
 export type HandleCartIconClickParam = Product & { isInCart: boolean };

--- a/code/src/containers/user-account/my-reservations/MyReservations.test.tsx
+++ b/code/src/containers/user-account/my-reservations/MyReservations.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import MyReservations from "@/containers/user-account/my-reservations/MyReservations";
 
-import { useGetMyReservationsQuery } from "@/store/tanstack-api/modules/reservations";
+import { useGetMyReservationsMetadataQuery, useGetMyReservationsQuery } from "@/store/tanstack-api/modules/reservations";
 import { useGetUserWishlistQuery } from "@/store/api/wishlistApi";
 import { useLocaleContext } from "@/context/i18n/I18nProvider";
 import usePagination from "@/hooks/use-pagination/usePagination";
@@ -14,6 +14,7 @@ jest.mock("@/context/i18n/I18nProvider");
 jest.mock("@/hooks/use-pagination/usePagination");
 jest.mock("@/utils/check-screen-size/useScreenSize");
 jest.mock("@/utils/set-product-size/setProductsPerPageSize");
+jest.mock("@/store/tanstack-api/modules/reservations");
 
 jest.mock(
     "@/containers/products-container/ProductsContainer",
@@ -55,6 +56,11 @@ describe("MyReservations", () => {
 
         (useGetMyReservationsQuery as jest.Mock).mockReturnValue({
             data: mockReservations,
+            isLoading: false
+        });
+
+        (useGetMyReservationsMetadataQuery as jest.Mock).mockReturnValue({
+            data: { reservations: mockReservations },
             isLoading: false
         });
 

--- a/code/src/containers/user-account/my-reservations/MyReservations.tsx
+++ b/code/src/containers/user-account/my-reservations/MyReservations.tsx
@@ -2,7 +2,10 @@ import AppBox from "@/components/app-box/AppBox";
 import AppContainer from "@/components/app-container/AppContainer";
 import AppTypography from "@/components/app-typography/AppTypography";
 
-import { useGetMyReservationsQuery } from "@/store/tanstack-api/modules/reservations";
+import {
+    useGetMyReservationsMetadataQuery,
+    useGetMyReservationsQuery
+} from "@/store/tanstack-api/modules/reservations";
 import { useLocaleContext } from "@/context/i18n/I18nProvider";
 import usePagination from "@/hooks/use-pagination/usePagination";
 import setProductsPerPageSize from "@/utils/set-product-size/setProductsPerPageSize";
@@ -27,6 +30,7 @@ const MyReservations = () => {
             lang: locale
         }
     });
+    const { data: reservationsMetadata } = useGetMyReservationsMetadataQuery();
 
     const productsList = reservations ?? [];
     const productsCount = productsList.length;
@@ -68,6 +72,7 @@ const MyReservations = () => {
                 loadingItemsCount={10}
                 wishlist={wishlist}
                 maxColumns={3}
+                reservationsMetadata={reservationsMetadata?.reservations}
             />
             <PaginationBlock page={page} />
         </AppContainer>

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.scss
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.scss
@@ -55,6 +55,13 @@
     }
   }
 
+  &__badges-timer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding-right: spacing(2);
+  }
+
   &__in-stock {
     color: var(--spa-product-details-in-stock-color, $green);
   }

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.scss
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.scss
@@ -59,6 +59,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    align-items: flex-start;
     padding-right: spacing(2);
   }
 

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.test.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.test.tsx
@@ -100,6 +100,11 @@ jest.mock(
         ))
     })
 );
+jest.mock("@/store/tanstack-api/modules/reservations/queries", () => ({
+    useGetMyReservationsMetadataQuery: jest.fn(() => ({
+        data: { reservations: [] }
+    }))
+}));
 
 type MockState = RTKQueryMockState<
     typeof mockProduct,

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
@@ -192,7 +192,7 @@ const ProductDetailsContainer = ({
       </AppBox>
       <AppBox className="product-details__summary">
         <AppBox className="product-details__badges-timer">
-          <AppBox style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <AppBox style={{ display: "flex", alignItems: "flex-start", gap: "8px" }}>
             {categoryBadge}
             {bestsellerBadge}
           </AppBox>

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
@@ -12,6 +12,7 @@ import AppIconButton from "@/components/app-icon-button/AppIconButton";
 import AppTypography from "@/components/app-typography/AppTypography";
 import PriceLabel from "@/components/price-label/PriceLabel";
 import ProductDescription from "@/components/product-description/ProductDescription";
+import CircularCountdown from "@/components/circular-countdown/CircularCountdown";
 
 import { deliveryMethods as deliveryMethodsData } from "@/constants/deliveryMethods";
 import { useLocaleContext } from "@/context/i18n/I18nProvider";

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
@@ -24,6 +24,7 @@ import { productNotFoundRedirectConfig } from "@/pages/product-details/ProductsD
 import BuyNowButton from "@/pages/product-details/components/buy-now-button/BuyNowButton";
 import ReserveButtonContainer from "@/pages/product-details/components/reserve-button-container/ReserveButtonContainer";
 import { useGetUserProductByIdQuery } from "@/store/api/productsApi";
+import { useGetMyReservationsMetadataQuery } from "@/store/tanstack-api/modules/reservations/queries";
 import getCategoryFromTags from "@/utils/get-category-from-tags/getCategoryFromTags";
 import isErrorWithStatus from "@/utils/is-error-with-status/isErrorWithStatus";
 import cn from "@/utils/cn/cn";
@@ -57,6 +58,8 @@ const ProductDetailsContainer = ({
     productId,
     lang: locale
   });
+
+  const { data: reservationsMetadata } = useGetMyReservationsMetadataQuery();
 
   const isAuthenticated = useIsAuthSelector();
   const { openModal } = useModalContext();
@@ -170,6 +173,10 @@ const ProductDetailsContainer = ({
 
   const isProductFavorite = isFavorite(productId);
 
+  const currentReservation = reservationsMetadata?.reservations?.find(
+    reservation => reservation.id === productId
+  );
+
   return (
     <AppBox className="product-details">
       <AppBox className="product-details__image-wrapper">
@@ -185,6 +192,12 @@ const ProductDetailsContainer = ({
           {categoryBadge}
           {bestsellerBadge}
         </AppBox>
+        {currentReservation && (
+          <CircularCountdown
+            reservedAt={currentReservation.reservedAt}
+            size={50}
+          />
+        )}
         <AppTypography variant="h3" component="h1">
           {product.name}
         </AppTypography>

--- a/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
+++ b/code/src/pages/product-details/components/product-details-container/ProductDetailsContainer.tsx
@@ -29,6 +29,7 @@ import getCategoryFromTags from "@/utils/get-category-from-tags/getCategoryFromT
 import isErrorWithStatus from "@/utils/is-error-with-status/isErrorWithStatus";
 import cn from "@/utils/cn/cn";
 import { getProductStatus } from "@/utils/get-product-status/getProductStatus";
+import { isUserAllowed } from "@/utils/is-user-allowed/isUserAllowed";
 import { Product } from "@/types/product.types";
 import { useModalContext } from "@/context/modal/ModalContext";
 import { useIsAuthSelector, useUserRoleSelector } from "@/store/slices/userSlice";
@@ -59,11 +60,13 @@ const ProductDetailsContainer = ({
     lang: locale
   });
 
-  const { data: reservationsMetadata } = useGetMyReservationsMetadataQuery();
-
   const isAuthenticated = useIsAuthSelector();
   const { openModal } = useModalContext();
   const userRole = useUserRoleSelector();
+
+  const canUserInteract = !isUserAllowed(isAuthenticated, userRole);
+
+  const { data: reservationsMetadata } = useGetMyReservationsMetadataQuery(!canUserInteract);
 
   const isUserOrGuest = !userRole || userRole === ROLES.USER;
 
@@ -188,16 +191,18 @@ const ProductDetailsContainer = ({
         )}
       </AppBox>
       <AppBox className="product-details__summary">
-        <AppBox style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-          {categoryBadge}
-          {bestsellerBadge}
+        <AppBox className="product-details__badges-timer">
+          <AppBox style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            {categoryBadge}
+            {bestsellerBadge}
+          </AppBox>
+          {currentReservation && (
+            <CircularCountdown
+              reservedAt={currentReservation.reservedAt}
+              size={60}
+            />
+          )}
         </AppBox>
-        {currentReservation && (
-          <CircularCountdown
-            reservedAt={currentReservation.reservedAt}
-            size={50}
-          />
-        )}
         <AppTypography variant="h3" component="h1">
           {product.name}
         </AppTypography>

--- a/code/src/store/tanstack-api/modules/reservations/queries.ts
+++ b/code/src/store/tanstack-api/modules/reservations/queries.ts
@@ -3,7 +3,8 @@ import { reservationsApi } from "@/store/tanstack-api/modules/reservations/reser
 import { reservationsKeys } from "@/store/tanstack-api/modules/reservations/queryKeys";
 import {
   GetMyReservationsParams,
-  ReservationProductParams
+  ReservationProductParams,
+  GetMyReservationsMetadataResponse,
 } from "@/types/product.types";
 
 type UseGetMyReservationsArgs = {
@@ -48,3 +49,10 @@ export const useRemoveFromReservationsMutation = () => {
     },
   });
 };
+
+export const useGetMyReservationsMetadataQuery = (enabled = true) =>
+  useQuery<GetMyReservationsMetadataResponse>({
+    queryKey: reservationsKeys.myReservationsMetadata(),
+    queryFn: () => reservationsApi.getMyReservationsMetadata(),
+    enabled,
+  });

--- a/code/src/store/tanstack-api/modules/reservations/queryKeys.ts
+++ b/code/src/store/tanstack-api/modules/reservations/queryKeys.ts
@@ -3,4 +3,6 @@ export const reservationsKeys = {
 
   myReservations: () =>
     [...reservationsKeys.all, "myReservations"] as const,
+  myReservationsMetadata: () =>
+    [...reservationsKeys.all, "metadata"] as const,
 };

--- a/code/src/store/tanstack-api/modules/reservations/reservationsApi.ts
+++ b/code/src/store/tanstack-api/modules/reservations/reservationsApi.ts
@@ -7,6 +7,7 @@ import {
   GetMyReservationsParams,
   GetMyReservationsResponse,
   ReservationProductParams,
+  GetMyReservationsMetadataResponse,
 } from "@/types/product.types";
 
 export const reservationsApi = {
@@ -40,4 +41,10 @@ export const reservationsApi = {
       }
     );
   },
+
+  getMyReservationsMetadata: () =>
+    fetcher<GetMyReservationsMetadataResponse>(
+      URLS.reservations.getMyReservationsMetadata,
+      { method: httpMethods.get }
+    ),
 };

--- a/code/src/types/product.types.ts
+++ b/code/src/types/product.types.ts
@@ -264,3 +264,14 @@ export type GetMyReservationsParams = Lang & Omit<Pageable, "sort"> & {
 };
 
 export type GetMyReservationsResponse = Product[];
+
+export type ReservationMetadata = {
+  id: string;
+  reservedAt: string;
+};
+
+export type GetMyReservationsMetadataResponse = {
+  remainingMoney: string;
+  remainingItems: number;
+  reservations: ReservationMetadata[];
+};


### PR DESCRIPTION
- Implemented `CircularCountdown` to `ProductCard`, `SaleProductCard` and `ProductDetails` page.
- Added `getMyReservationsMetadata` endpoint `(/v1/my-reservations/metadata)` and corresponding TanStack Query hook to fetch user reservations metadata
- Added relevant styles

<img width="1337" height="707" alt="image" src="https://github.com/user-attachments/assets/483e8b4d-aa08-4dcd-ab24-77f6a8b7fe0a" />
<img width="1187" height="712" alt="image" src="https://github.com/user-attachments/assets/5d09eaa3-4ce5-4a01-9c9d-d319da3c7bcc" />

Task: [281](https://team-gs2.atlassian.net/browse/GS2-281)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live countdown timers now appear on product cards, sale cards, and product details for reserved items.
  * Reservation metadata is now fetched and used across product lists (including My Reservations) to show accurate reservation timestamps and enable timers.

* **Style**
  * Layout adjustments to position badges and countdown timers alongside product labels for consistent spacing and alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->