### PR TITLE
[GS2-252] Implement Reserved quantity in ProductsTable for MANAGER

### DIFF
--- a/code/src/components/reserved-product-details/ReservedProductDetails.test.tsx
+++ b/code/src/components/reserved-product-details/ReservedProductDetails.test.tsx
@@ -23,6 +23,7 @@ describe("ReservedProductDetails", () => {
     id: "1",
     image: "test-image.png",
     quantity: 5,
+    reservedQuantity: 2,
     price: 100,
     priceWithDiscount: 80,
     discount: 20,

--- a/code/src/containers/forms/product-form/components/update-product-form/UpdateProductForm.test.tsx
+++ b/code/src/containers/forms/product-form/components/update-product-form/UpdateProductForm.test.tsx
@@ -49,6 +49,7 @@ const testData: FullManagerProduct = {
   status: "HIDDEN",
   image: "https://example.com",
   quantity: 10,
+  reservedQuantity: 2,
   price: 100,
   tags: [{ id: 1, name: "category:mobile" }],
   priceWithDiscount: null,

--- a/code/src/containers/forms/product-form/utils/get-default-values/getDefaultValues.test.ts
+++ b/code/src/containers/forms/product-form/utils/get-default-values/getDefaultValues.test.ts
@@ -9,6 +9,7 @@ const product: FullManagerProduct = {
     "https://j65jb0fdkxuua0go.public.blob.vercel-storage.com/phone_1-QodrkqNjm6MWrKqg9ixBBMMfFU40X7.jpg",
   createdAt: "2024-07-29T20:20:02.404Z",
   quantity: 10,
+  reservedQuantity: 2,
   price: 999.99,
   percentageOfTotalOrders: null,
   priceWithDiscount: null,

--- a/code/src/containers/tables/products-table/ProductsTable.constants.ts
+++ b/code/src/containers/tables/products-table/ProductsTable.constants.ts
@@ -28,6 +28,7 @@ export const mockProducts: ManagerProduct[] = [
     imageLink:
       "https://j65jb0fdkxuua0go.public.blob.vercel-storage.com/phone_1-QodrkqNjm6MWrKqg9ixBBMMfFU40X7.jpg",
     quantity: 10,
+    reservedQuantity: 5,
     price: 100.45,
     priceWithDiscount: 5,
     percentageOfTotalOrders: null,
@@ -44,6 +45,7 @@ export const mockProducts: ManagerProduct[] = [
     imageLink:
       "https://j65jb0fdkxuua0go.public.blob.vercel-storage.com/phone_2-tTDYhyoyqsEkwPzySFdXflYCe7TkUb.jpg",
     quantity: 10,
+    reservedQuantity: 2,
     price: 100.45,
     priceWithDiscount: null,
     percentageOfTotalOrders: null,

--- a/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.scss
+++ b/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.scss
@@ -11,10 +11,6 @@
 
     background-color: var(--products-table-body-bg-color, $white);
 
-    &:hover {
-      background-color: var(--color-muted);
-    }
-
     &-name {
       @include text-truncate($line-clamp: 2);
 

--- a/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.scss
+++ b/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.scss
@@ -11,6 +11,10 @@
 
     background-color: var(--products-table-body-bg-color, $white);
 
+    &:hover {
+      background-color: var(--color-disabled);
+    }
+
     &-name {
       @include text-truncate($line-clamp: 2);
 

--- a/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.tsx
+++ b/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.tsx
@@ -3,7 +3,6 @@ import EditIcon from "@mui/icons-material/Edit";
 import { ProductsTableBodyProps } from "@/containers/tables/products-table/ProductsTable.types";
 
 import AppBox from "@/components/app-box/AppBox";
-import AppButton from "@/components/app-button/AppButton";
 import AppIconButton from "@/components/app-icon-button/AppIconButton";
 import AppLink from "@/components/app-link/AppLink";
 import { AppTableCell } from "@/components/app-table/components";

--- a/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.tsx
+++ b/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.tsx
@@ -7,6 +7,7 @@ import AppIconButton from "@/components/app-icon-button/AppIconButton";
 import AppLink from "@/components/app-link/AppLink";
 import { AppTableCell } from "@/components/app-table/components";
 import AppTypography from "@/components/app-typography/AppTypography";
+import AppTooltip from "@/components/app-tooltip/AppTooltip";
 import DraftLabel from "@/components/draft-label/DraftLabel";
 
 import routes from "@/constants/routes";
@@ -32,6 +33,8 @@ const ProductsTableBody = ({ product }: ProductsTableBodyProps) => {
     priceWithDiscount,
     discount
   } = product;
+
+  const totalQuantity = quantity + reservedQuantity;
 
   const categoryName = getCategoryFromTags(tags);
 
@@ -70,7 +73,19 @@ const ProductsTableBody = ({ product }: ProductsTableBodyProps) => {
       </AppTableCell>
       <AppTableCell>{nameElement}</AppTableCell>
       <AppTableCell>{category}</AppTableCell>
-      <AppTableCell>{quantity}</AppTableCell>
+      <AppTableCell>
+        <AppTooltip
+          titleTranslationKey="productsTable.totalQuantity"
+          titleTranslationProps={{ values: { total: totalQuantity } }}
+        >
+          <AppTypography
+            variant="caption"
+            component="span"
+          >
+            {quantity}
+          </AppTypography>
+        </AppTooltip>
+      </AppTableCell>
       <AppTableCell>
         <AppLink to={routes.dashboard.products.reservationsDetails.path(id)}>
           <AppTypography

--- a/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.tsx
+++ b/code/src/containers/tables/products-table/components/products-table-body/ProductsTableBody.tsx
@@ -25,6 +25,7 @@ const ProductsTableBody = ({ product }: ProductsTableBodyProps) => {
     imageLink,
     price,
     quantity,
+    reservedQuantity,
     status,
     tags,
     createdAt,
@@ -72,20 +73,14 @@ const ProductsTableBody = ({ product }: ProductsTableBodyProps) => {
       <AppTableCell>{category}</AppTableCell>
       <AppTableCell>{quantity}</AppTableCell>
       <AppTableCell>
-        {/* TODO: Replace with reserved quantity */}
-        <AppButton
-          className="products-table__body-reserved-button"
-          type="button"
-          size="small"
-          variant="outlined"
-          to={routes.dashboard.products.reservationsDetails.path(id)}
-        >
+        <AppLink to={routes.dashboard.products.reservationsDetails.path(id)}>
           <AppTypography
             variant="caption"
             component="span"
-            translationKey="productsTable.reservedButton"
-          />
-        </AppButton>
+          >
+            {reservedQuantity}
+          </AppTypography>
+        </AppLink>
       </AppTableCell>
       <AppTableCell>{formatPrice(price)}</AppTableCell>
       <AppTableCell

--- a/code/src/containers/tables/products-table/messages/en.json
+++ b/code/src/containers/tables/products-table/messages/en.json
@@ -9,5 +9,6 @@
   "productsTable.fallback": "No products found",
   "productsTable.label.draft": "Draft",
   "productsTable.reservedButton": "Reserved",
-  "productsTable.label.reservedLabel": "Reserved"
+  "productsTable.label.reservedLabel": "Reserved",
+  "productsTable.totalQuantity": "Total quantity: {total}"
 }

--- a/code/src/containers/tables/products-table/messages/uk.json
+++ b/code/src/containers/tables/products-table/messages/uk.json
@@ -9,5 +9,6 @@
   "productsTable.fallback": "Продуктів не знайдено",
   "productsTable.label.draft": "Чернетка",
   "productsTable.reservedButton": "Резерв",
-  "productsTable.label.reservedLabel": "Зарезервовано"
+  "productsTable.label.reservedLabel": "Зарезервовано",
+  "productsTable.totalQuantity": "Загальна кількість: {total}"
 }

--- a/code/src/pages/dashboard/dashboard-product/components/dashboard-product-container/DashboardProductContainer.test.tsx
+++ b/code/src/pages/dashboard/dashboard-product/components/dashboard-product-container/DashboardProductContainer.test.tsx
@@ -31,6 +31,7 @@ const managerProduct: GetManagerProductByIdResponse = {
     "https://j65jb0fdkxuua0go.public.blob.vercel-storage.com/phone_1-QodrkqNjm6MWrKqg9ixBBMMfFU40X7.jpg",
   createdAt: "2024-07-29T20:20:02.404Z",
   quantity: 10,
+  reservedQuantity: 2,
   percentageOfTotalOrders: null,
   price: 999.99,
   priceWithDiscount: 3,

--- a/code/src/types/product.types.ts
+++ b/code/src/types/product.types.ts
@@ -26,6 +26,7 @@ export type ManagerProduct = {
   description: string;
   imageLink: string;
   quantity: number;
+  reservedQuantity: number;
   price: number;
   createdAt: string;
   status: ManagerProductStatus;
@@ -153,6 +154,7 @@ export type GetManagerProductByIdResponse = {
   image: string;
   createdAt: string;
   quantity: number;
+  reservedQuantity: number;
   percentageOfTotalOrders: number | null;
   price: number;
   discount: number | null;


### PR DESCRIPTION
Added new field `reservedQuantity` for `ManagerProduct`.

Changed `Reserved` button to clickable Reserved quantity field:

Before changes:
<img width="1406" height="763" alt="image" src="https://github.com/user-attachments/assets/8ffd1578-4e3d-4bd4-a67e-6126cc567752" />

After:
<img width="1375" height="769" alt="image" src="https://github.com/user-attachments/assets/6a970bdf-e867-4fe0-9c3b-2abb91e788c7" />

Added hover `"Total quantity:"` over Quantity fields, that contains the sum of the fields `Quantity` and `reservedQuantity`:
<img width="1359" height="186" alt="image" src="https://github.com/user-attachments/assets/8a491153-4fb5-4694-af99-0a8c1a5fcb63" />
Changed color of hover over rows.

Tasks: [252](https://team-gs2.atlassian.net/browse/GS2-252), [254](https://team-gs2.atlassian.net/browse/GS2-254)